### PR TITLE
S-550 support: device-agnostic editor architecture

### DIFF
--- a/modules/sampler-editor/src/configs/memory-layout.ts
+++ b/modules/sampler-editor/src/configs/memory-layout.ts
@@ -76,6 +76,12 @@ export function createS330MemoryLayout(): MemoryLayout {
       return `P${bankSlotLabel(firstIndex, slotsPerBank)}-P${bankSlotLabel(lastIndex, slotsPerBank)}`;
     },
 
+    formatToneBankLabel(bankIndex: number, tonesPerBank: number): string {
+      const firstIndex = bankIndex * tonesPerBank;
+      const lastIndex = firstIndex + tonesPerBank - 1;
+      return `T${bankSlotLabel(firstIndex, slotsPerBank)}-T${bankSlotLabel(lastIndex, slotsPerBank)}`;
+    },
+
     patchLabelsUseSerif: false,
   };
 }
@@ -161,6 +167,12 @@ export function createS550MemoryLayout(): MemoryLayout {
       const firstLocalIndex = firstIndex % patchesPerBlock;
       const lastLocalIndex = lastIndex % patchesPerBlock;
       return `${firstBlock}${bankSlotLabel(firstLocalIndex, slotsPerBank)}-${lastBlock}${bankSlotLabel(lastLocalIndex, slotsPerBank)}`;
+    },
+
+    formatToneBankLabel(bankIndex: number, tonesPerBank: number): string {
+      const firstIndex = bankIndex * tonesPerBank;
+      const lastIndex = firstIndex + tonesPerBank - 1;
+      return `T${bankSlotLabel(firstIndex, slotsPerBank)}-T${bankSlotLabel(lastIndex, slotsPerBank)}`;
     },
 
     patchLabelsUseSerif: true,

--- a/modules/sampler-editor/src/configs/types.ts
+++ b/modules/sampler-editor/src/configs/types.ts
@@ -101,6 +101,11 @@ export interface MemoryLayout {
   formatPatchBankLabel(bankIndex: number, patchesPerBank: number): string;
 
   /**
+   * Format a tone bank label for load buttons (e.g., bank 0 → "T11-T18").
+   */
+  formatToneBankLabel(bankIndex: number, tonesPerBank: number): string;
+
+  /**
    * Whether patch labels use Roman numerals (I, II) and should be rendered in serif font.
    * S-550 uses Roman numerals for blocks, S-330 uses P prefix.
    */

--- a/modules/sampler-editor/src/pages/TonesPage.tsx
+++ b/modules/sampler-editor/src/pages/TonesPage.tsx
@@ -1,8 +1,9 @@
 /**
- * Tones page - View and edit S-330 tones
+ * Tones page - View and edit sampler tones
  *
  * Data is cached in deviceDataStore and persists across page navigation.
  * Loads first bank (8 tones) by default for faster startup.
+ * The number of tone banks adapts to the device (S-330: 4 banks, S-550: 8 banks).
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -525,50 +526,20 @@ export function TonesPage() {
             )}
             <div className="flex items-center gap-2">
               <span className="text-sm text-s330-muted">(Re)load:</span>
-              <button
-                onClick={() => loadToneBank(0, true)}
-                disabled={isLoading}
-                className={cn(
-                  'ac-btn ac-btn-sm',
-                  loadedBanks.includes(0) ? 'ac-btn-secondary' : 'ac-btn-primary',
-                  isLoading && 'opacity-50'
-                )}
-              >
-                T11-T18
-              </button>
-              <button
-                onClick={() => loadToneBank(1, true)}
-                disabled={isLoading}
-                className={cn(
-                  'ac-btn ac-btn-sm',
-                  loadedBanks.includes(1) ? 'ac-btn-secondary' : 'ac-btn-primary',
-                  isLoading && 'opacity-50'
-                )}
-              >
-                T21-T28
-              </button>
-              <button
-                onClick={() => loadToneBank(2, true)}
-                disabled={isLoading}
-                className={cn(
-                  'ac-btn ac-btn-sm',
-                  loadedBanks.includes(2) ? 'ac-btn-secondary' : 'ac-btn-primary',
-                  isLoading && 'opacity-50'
-                )}
-              >
-                T31-T38
-              </button>
-              <button
-                onClick={() => loadToneBank(3, true)}
-                disabled={isLoading}
-                className={cn(
-                  'ac-btn ac-btn-sm',
-                  loadedBanks.includes(3) ? 'ac-btn-secondary' : 'ac-btn-primary',
-                  isLoading && 'opacity-50'
-                )}
-              >
-                T41-T48
-              </button>
+              {Array.from({ length: Math.ceil(totalTones / tonesPerBank) }, (_, bankIndex) => (
+                <button
+                  key={bankIndex}
+                  onClick={() => loadToneBank(bankIndex, true)}
+                  disabled={isLoading}
+                  className={cn(
+                    'ac-btn ac-btn-sm',
+                    loadedBanks.includes(bankIndex) ? 'ac-btn-secondary' : 'ac-btn-primary',
+                    isLoading && 'opacity-50'
+                  )}
+                >
+                  {config.memoryLayout.formatToneBankLabel(bankIndex, tonesPerBank)}
+                </button>
+              ))}
               <button
                 onClick={loadAll}
                 disabled={isLoading}


### PR DESCRIPTION
## Summary

- Add S-550 device module with shared S-series base infrastructure
- Implement device-agnostic editor with runtime device configuration
- Add memory layout interface for device-specific UI rendering
- Dynamically generate tone/patch bank reload buttons based on device config
- Add loop editor with automatic loop point detection
- Implement sample chopper with trigger-based slicing and library integration
- Add Google Drive and S3 storage adapters for library
- Create shared editor-core components for cross-editor reuse
- Implement incremental Make-based build system

## Test plan

- [x] S-330 editor functions correctly with existing behavior
- [x] S-550 editor renders correct memory layout (8 tone banks, 2 patch blocks)
- [x] Loop editor detects and saves loop points
- [x] Sample chopper slices and exports to library
- [x] Library operations work with local and Google Drive storage