### PR TITLE
feat: 31 E2E tests — envelopes, section visibility, sample headers

### DIFF
--- a/modules/akai-s3k-editor/e2e/device-keygroups.spec.ts
+++ b/modules/akai-s3k-editor/e2e/device-keygroups.spec.ts
@@ -99,6 +99,46 @@ function numberInputByLabel(
     .locator('input[type="number"]');
 }
 
+/**
+ * Locate a NumberInput by label within a specific named section.
+ *
+ * Scopes the search to a Section component with the given title, avoiding
+ * ambiguity when multiple sections share the same parameter label names
+ * (e.g. "Attack" in Amplitude Envelope vs Filter Envelope).
+ */
+function numberInputByLabelInSection(
+  page: import('@playwright/test').Page,
+  sectionTitle: string,
+  label: string,
+): import('@playwright/test').Locator {
+  const section = page.locator('.border.border-gray-700', {
+    has: page.locator('.bg-gray-800', { hasText: sectionTitle }),
+  });
+  return section
+    .locator('.flex.items-center.justify-between', { hasText: label })
+    .filter({ has: page.locator('input[type="number"]') })
+    .locator('input[type="number"]');
+}
+
+/**
+ * Like numberInputByLabelInSection but uses exact text matching on the label
+ * span to avoid ambiguity (e.g., "Attack" vs "Vel -> Attack").
+ */
+function numberInputByExactLabelInSection(
+  page: import('@playwright/test').Page,
+  sectionTitle: string,
+  label: string,
+): import('@playwright/test').Locator {
+  const section = page.locator('.border.border-gray-700', {
+    has: page.locator('.bg-gray-800', { hasText: sectionTitle }),
+  });
+  return section
+    .locator('.flex.items-center.justify-between')
+    .filter({ has: page.locator(`span.text-sm.text-gray-400 >> text="${label}"`) })
+    .filter({ has: page.locator('input[type="number"]') })
+    .locator('input[type="number"]');
+}
+
 test.describe('S3000XL Keygroups Page', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(url());
@@ -198,6 +238,73 @@ test.describe('S3000XL Keygroups Page', () => {
 
       // Verify the value was read back from the device
       const reloadedInput = numberInputByLabel(page, 'Frequency');
+      await expect(reloadedInput).toHaveValue(testValue);
+
+      // Restore the original value
+      await reloadedInput.fill(originalValue);
+      await page.waitForTimeout(1_500);
+    });
+  });
+
+  test.describe('Keygroup Envelope Parameters', () => {
+    test.beforeEach(async ({ page }) => {
+      await selectFirstProgram(page);
+      await navigateToKeygroups(page);
+      await waitForKeygroupListLoaded(page);
+      await selectFirstKeygroupAndWaitForEditor(page);
+    });
+
+    test('amplitude envelope inputs are displayed', async ({ page }) => {
+      // The Amplitude Envelope (Env 1) section renders ADSR inputs
+      const ampEnvSection = page.locator('.border.border-gray-700', {
+        has: page.locator('.bg-gray-800', { hasText: 'Amplitude Envelope' }),
+      });
+      await expect(ampEnvSection).toBeVisible();
+
+      const attackInput = numberInputByExactLabelInSection(page, 'Amplitude Envelope', 'Attack');
+      const decayInput = numberInputByExactLabelInSection(page, 'Amplitude Envelope', 'Decay');
+      const sustainInput = numberInputByExactLabelInSection(page, 'Amplitude Envelope', 'Sustain');
+      const releaseInput = numberInputByExactLabelInSection(page, 'Amplitude Envelope', 'Release');
+
+      await expect(attackInput).toBeVisible();
+      await expect(decayInput).toBeVisible();
+      await expect(sustainInput).toBeVisible();
+      await expect(releaseInput).toBeVisible();
+
+      // Verify each input has a finite numeric value
+      for (const input of [attackInput, decayInput, sustainInput, releaseInput]) {
+        const value = Number(await input.inputValue());
+        expect(Number.isFinite(value)).toBe(true);
+      }
+    });
+
+    test('amplitude envelope attack round-trip persists to device', async ({ page }) => {
+      test.setTimeout(60_000);
+
+      // Use section-scoped locator to avoid matching Filter Envelope's "Attack" label
+      const attackInput = numberInputByExactLabelInSection(page, 'Amplitude Envelope', 'Attack');
+      await expect(attackInput).toBeVisible();
+
+      // Read the current value so we can restore it
+      const originalValue = await attackInput.inputValue();
+
+      // Pick a test value that differs from whatever the device has
+      const testValue = originalValue === '30' ? '60' : '30';
+
+      // Set the new value
+      await attackInput.fill(testValue);
+      await expect(attackInput).toHaveValue(testValue);
+
+      // Wait for the SysEx write to propagate to the device
+      await page.waitForTimeout(1_500);
+
+      // Click Refresh to invalidate caches and re-fetch from device
+      await page.locator('button', { hasText: 'Refresh' }).click();
+      await waitForKeygroupListLoaded(page);
+      await selectFirstKeygroupAndWaitForEditor(page);
+
+      // Verify the value was read back from the device
+      const reloadedInput = numberInputByExactLabelInSection(page, 'Amplitude Envelope', 'Attack');
       await expect(reloadedInput).toHaveValue(testValue);
 
       // Restore the original value

--- a/modules/akai-s3k-editor/e2e/device-programs.spec.ts
+++ b/modules/akai-s3k-editor/e2e/device-programs.spec.ts
@@ -323,4 +323,48 @@ test.describe('S3000XL Programs Page', () => {
       await page.waitForTimeout(1_500);
     });
   });
+
+  test.describe('Program Section Visibility', () => {
+    test.beforeEach(async ({ page }) => {
+      await navigateToPrograms(page);
+      await waitForProgramNamesLoaded(page);
+      await selectFirstProgramAndWaitForEditor(page);
+    });
+
+    test('Output section displays parameters', async ({ page }) => {
+      // The Output section should render with its key parameter labels
+      const outputSection = page.locator('.border.border-gray-700', {
+        has: page.locator('.bg-gray-800', { hasText: 'Output' }),
+      }).filter({ hasText: 'Output Routing' });
+
+      await expect(outputSection).toBeVisible();
+      await expect(outputSection.locator('text=Output Routing')).toBeVisible();
+      await expect(outputSection.locator('text=Stereo Level')).toBeVisible();
+      await expect(outputSection.locator('text=Program Level')).toBeVisible();
+    });
+
+    test('LFO 1 section displays parameters', async ({ page }) => {
+      // The LFO 1 section should render with Rate, Depth, and Delay
+      const lfo1Section = page.locator('.border.border-gray-700').filter({
+        has: page.locator('.bg-gray-800', { hasText: /^LFO 1$/ }),
+      });
+
+      await expect(lfo1Section).toBeVisible();
+      await expect(lfo1Section.locator('text=Rate')).toBeVisible();
+      await expect(lfo1Section.locator('text=Depth')).toBeVisible();
+      await expect(lfo1Section.locator('text=Delay')).toBeVisible();
+    });
+
+    test('Soft Pedal section displays parameters', async ({ page }) => {
+      // The Soft Pedal section should render with its three parameters
+      const softPedalSection = page.locator('.border.border-gray-700', {
+        has: page.locator('.bg-gray-800', { hasText: 'Soft Pedal' }),
+      });
+
+      await expect(softPedalSection).toBeVisible();
+      await expect(softPedalSection.locator('text=Loudness Reduction')).toBeVisible();
+      await expect(softPedalSection.locator('text=Attack Stretch')).toBeVisible();
+      await expect(softPedalSection.locator('text=Filter Reduction')).toBeVisible();
+    });
+  });
 });

--- a/modules/akai-s3k-editor/e2e/device-sample-headers.spec.ts
+++ b/modules/akai-s3k-editor/e2e/device-sample-headers.spec.ts
@@ -1,0 +1,148 @@
+/**
+ * Hardware e2e tests for sample header reading on Akai S3000XL.
+ *
+ * These tests require an actual Akai S3000XL connected via MIDI with
+ * at least one sample loaded in memory. They exercise the RSLIST SysEx
+ * path by verifying sample names are fetched and displayed in the
+ * velocity zone sample dropdown within the Keygroups editor.
+ *
+ * The S3000XL editor does not yet have a dedicated Samples page, so
+ * these tests use the velocity zone's sample select dropdown (populated
+ * by useSampleNames / fetchSampleNames) as the verification surface.
+ */
+
+import { test, expect } from '@playwright/test';
+
+// Deviation: Using relative import because e2e/ is outside src/ and @/ path alias
+// only applies to src/. This pattern should not be copied to application code.
+import {
+  buildUrl,
+  waitForAppReady,
+  connectToDevice,
+} from '../../e2e-infra/helpers/connection-helper';
+
+test.setTimeout(30_000);
+
+const MIDI_SERVER_PORT = process.env.E2E_MIDI_SERVER_PORT;
+const EDITOR_BASE_PATH = '/akai/s3000xl/editor';
+
+function url(subpath: string = ''): string {
+  return buildUrl(EDITOR_BASE_PATH, subpath, MIDI_SERVER_PORT);
+}
+
+/**
+ * Navigate to Programs page, wait for program names to load from device,
+ * and select the first program so that keygroup data is available.
+ */
+async function selectFirstProgram(page: import('@playwright/test').Page): Promise<void> {
+  const programsLink = page.locator('a[href*="programs"]');
+  await programsLink.click();
+  await page.waitForURL('**/programs**');
+
+  await expect(page.locator('[data-testid="program-item-0"]')).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await page.locator('[data-testid="program-item-0"]').click();
+  await expect(page.locator('input[type="text"][maxlength="12"]')).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Navigate to the Keygroups page via the nav link.
+ * Assumes a program has already been selected.
+ */
+async function navigateToKeygroups(page: import('@playwright/test').Page): Promise<void> {
+  const keygroupsLink = page.locator('a[href*="keygroups"]');
+  await keygroupsLink.click();
+  await page.waitForURL('**/keygroups**');
+}
+
+/**
+ * Wait for at least one keygroup item to appear in the list.
+ */
+async function waitForKeygroupListLoaded(page: import('@playwright/test').Page): Promise<void> {
+  await expect(page.locator('button', { hasText: 'KG 1' })).toBeVisible({
+    timeout: 15_000,
+  });
+}
+
+/**
+ * Select the first keygroup and wait for the editor to render.
+ */
+async function selectFirstKeygroupAndWaitForEditor(
+  page: import('@playwright/test').Page,
+): Promise<void> {
+  await page.locator('button', { hasText: 'KG 1' }).click();
+  await expect(page.locator('text=Keygroup 1:').first()).toBeVisible({
+    timeout: 10_000,
+  });
+}
+
+/**
+ * Locate the sample name select within the velocity zone editor.
+ * The VelocityZoneEditor renders a SampleNameSelect dropdown for
+ * the active zone, populated from the device's resident sample list.
+ */
+function zoneSampleSelect(
+  page: import('@playwright/test').Page,
+): import('@playwright/test').Locator {
+  const velocityZonesSection = page.locator('.border.border-gray-700', {
+    has: page.locator('text=Velocity Zones'),
+  });
+  return velocityZonesSection
+    .locator('.flex.items-center.justify-between', { hasText: 'Sample' })
+    .locator('select')
+    .first();
+}
+
+test.describe('S3000XL Sample Headers', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(url());
+    await waitForAppReady(page);
+    await connectToDevice(page);
+    await selectFirstProgram(page);
+    await navigateToKeygroups(page);
+    await waitForKeygroupListLoaded(page);
+    await selectFirstKeygroupAndWaitForEditor(page);
+  });
+
+  test('sample names are loaded in velocity zone dropdown', async ({ page }) => {
+    // The sample select dropdown should have more options than just "(none)"
+    // if samples are resident on the device. This verifies the RSLIST SysEx
+    // request successfully fetched sample names from the S3000XL.
+    const sampleSelect = zoneSampleSelect(page);
+    await expect(sampleSelect).toBeVisible();
+
+    // Wait for sample names to load from device (RSLIST SysEx).
+    // The dropdown starts with just "(none)" and populates asynchronously.
+    await expect(async () => {
+      const count = await sampleSelect.locator('option').count();
+      expect(count).toBeGreaterThan(1);
+    }).toPass({ timeout: 15_000 });
+  });
+
+  test('sample dropdown options contain non-empty sample names', async ({ page }) => {
+    // Verify that at least one sample option has a meaningful name
+    // (not empty, not just whitespace). This confirms the RSLIST response
+    // was parsed correctly into displayable sample names.
+    const sampleSelect = zoneSampleSelect(page);
+    await expect(sampleSelect).toBeVisible();
+
+    const options = sampleSelect.locator('option');
+    const count = await options.count();
+
+    // Skip the first option which is "(none)"
+    let foundNonEmpty = false;
+    for (let i = 1; i < count; i++) {
+      const text = await options.nth(i).textContent();
+      if (text && text.trim().length > 0 && text.trim() !== '(unnamed)') {
+        foundNonEmpty = true;
+        break;
+      }
+    }
+
+    expect(foundNonEmpty).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

7 new E2E tests. All 31 pass against real S3000XL hardware.

- Program section visibility: Output, LFO 1, Soft Pedal (3)
- Keygroup envelope: ADSR display + attack round-trip (2)
- Sample headers: RSLIST name loading + validation (2)

Four SysEx paths verified: RPDATA/PDATA, RKDATA/KDATA, RSLIST, RSDATA.