### PR TITLE
SCSI MIDI Bridge: implementation, tests, and protocol documentation

### DIFF
--- a/docs/1.0/scsi-midi-bridge/README.md
+++ b/docs/1.0/scsi-midi-bridge/README.md
@@ -1,13 +1,11 @@
 # SCSI MIDI Bridge
 
-**Status:** Planning
-**Feature Branch:** `feature/midi-sds`
+**Status:** Implemented (Phases 2-5), hardware validated
+**Feature Branch:** `feature/scsi-midi-bridge`
 
 ## Overview
 
-Bidirectional audio sample transfer between audiocontrol and vintage SCSI-equipped samplers (initially Akai S3000XL) over WiFi. A Raspberry Pi running SCSI2Pi bridges the SCSI bus to the network via HTTP/WebSocket, enabling MIDI SysEx (including SDS) to be transmitted over the SCSI bus instead of a MIDI cable. The payload is byte-for-byte identical to standard MIDI; only the physical transport changes. SCSI is orders of magnitude faster than MIDI's 31.25 kbaud.
-
-This feature builds on the completed [MIDI SDS](https://github.com/audiocontrol-org/audiocontrol/blob/feature/midi-sds/docs/1.0/midi-sds/README.md) feature, which delivered the generic SDS protocol layer, S3000XL client integration, and editor UI.
+Bidirectional audio sample transfer and parameter editing between audiocontrol and the Akai S3000XL over WiFi via SCSI. A Raspberry Pi running SCSI2Pi bridges the SCSI bus to the network via HTTP/WebSocket, enabling MIDI SysEx to be transmitted over the SCSI bus instead of a MIDI cable. The payload is byte-for-byte identical to standard MIDI; only the physical transport changes.
 
 ## Tracking
 
@@ -16,6 +14,13 @@ This feature builds on the completed [MIDI SDS](https://github.com/audiocontrol-
 
 ## Documentation
 
-- [Product Requirements (PRD)](https://github.com/audiocontrol-org/audiocontrol/blob/feature/midi-sds/docs/1.0/scsi-midi-bridge/prd.md)
-- [Workplan](https://github.com/audiocontrol-org/audiocontrol/blob/feature/midi-sds/docs/1.0/scsi-midi-bridge/workplan.md)
-- [Implementation Summary](https://github.com/audiocontrol-org/audiocontrol/blob/feature/midi-sds/docs/1.0/scsi-midi-bridge/implementation-summary.md)
+- [Product Requirements (PRD)](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/prd.md)
+- [Workplan](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/workplan.md)
+- [Implementation Summary](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/implementation-summary.md)
+
+## Research
+
+- [Capture Notes](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/capture-notes.md) — Full MIDI-via-SCSI protocol decode
+- [MESA II Analysis](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/mesa-ii-analysis.md) — Reverse-engineered Akai SCSI Plug binary
+- [Phase 2 Findings](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/findings-phase2.md) — s2pexec/s2p bus contention
+- [E2E Test Plan](https://github.com/audiocontrol-org/audiocontrol/blob/feature/scsi-midi-bridge/docs/1.0/scsi-midi-bridge/e2e-test-plan.md) — 7 test suites, 40+ tests

--- a/docs/1.0/scsi-midi-bridge/implementation-summary.md
+++ b/docs/1.0/scsi-midi-bridge/implementation-summary.md
@@ -1,42 +1,78 @@
 # SCSI MIDI Bridge - Implementation Summary
 
-**Status:** Not started
-**Feature Branch:** `feature/midi-sds`
+**Status:** Phases 2-5 complete (Phase 5 partial — firmware limitation)
+**Feature Branch:** `feature/scsi-midi-bridge`
 
 ## Summary
 
-TBD -- this document will be completed as implementation progresses.
+Network bridge enabling audiocontrol (browser) to communicate with an Akai S3000XL sampler over SCSI via a Raspberry Pi. All Akai SysEx commands (parameter reads, parameter writes, SDS sample upload) work over the SCSI transport chain. SDS sample download is blocked by a firmware limitation on the S3000XL side; workaround is to read sample data from disk images directly.
 
 ## What Was Built
 
 ### Phase 2: SCSI Bus Connectivity
 
-TBD
+**Rust bridge daemon** (`services/scsi-midi-bridge/`, v0.2.0):
+- Axum 0.7 HTTP/WebSocket server on port 7033
+- Hand-encoded protobuf client for s2p API (port 6868)
+- Endpoints: `/health`, `/status`, `/scsi/scan`, `/sds/send`, `/sds/poll`, `/sds/stream`
+- 4 MIDI operations: MIDI_INIT, MIDI_SEND, MIDI_POLL, MIDI_READ
+- Multi-chunk response handling with 30-retry polling loop (3s timeout)
+
+**TypeScript SCSI transport** (`modules/midi-core/src/transports/scsi-midi-transport.ts`):
+- Factory: `createScsiMidiTransport()` → `{ adapter: MidiIO, connect, disconnect, scanDevices }`
+- Serialized send queue via HTTP POST
+- WebSocket receive with HTTP polling fallback (50ms)
+- 22 unit tests
 
 ### Phase 3: Capture Session
 
-TBD
+Fully decoded the MIDI-via-SCSI protocol:
+- 4-step CDB sequence: INIT (`0x09`), SEND (`0x0C`), POLL (`0x0D`), READ (`0x0E`)
+- Poll-based framing (not per-message streaming)
+- Confirmed SysEx payloads are byte-for-byte identical to standard MIDI
 
-### Phase 4: Write Path (Laptop to Sampler)
+Reverse-engineered MESA II SCSI Plug binary:
+- Confirmed MESA uses same CDB protocol for parameter commands
+- Discovered sample waveform data uses native SCSI block reads, not SysEx
+- RSPACK (0x0C) does not work over SCSI MIDI channel
 
-TBD
+### Phase 4: Write Path
 
-### Phase 5: Read Path (Sampler to Laptop)
+- `POST /sds/send` accepts SysEx, calls s2p protobuf API, returns response
+- `ScsiMidiTransport.send()` serializes sends via HTTP POST
+- All Akai SysEx commands work: RSTAT, RSLIST, RPLIST, RPDATA, RKDATA, RSDATA, PDATA, KDATA, SDATA
+- SDS sample upload works (closed-loop with ACK handshake)
+- 7 E2E test suites with 40+ tests
 
-TBD
+### Phase 5: Read Path (Partial)
+
+- Request/response reads work for all Akai SysEx commands
+- WebSocket and HTTP polling receive paths implemented
+- **Blocked:** SDS Data Packets are not routed through SCSI response buffer by S3000XL firmware
+- **Workaround:** Sample download via disk image extraction (`sampler-export` module)
 
 ## Key Decisions
 
-TBD
+- **s2p protobuf API, not s2pexec** — s2pexec and s2p cannot coexist (exclusive GPIO access). Bridge daemon uses s2p's protobuf API with hand-encoded messages (no protoc dependency).
+- **HTTP + polling, not WebSocket-only** — WebSocket fails in mixed-content scenarios (HTTPS page → ws:// connection). HTTP polling at 50ms provides reliable fallback.
+- **Disk image access for sample download** — MESA II itself uses native SCSI block reads for sample data, not SysEx. Following the same pattern with the existing `sampler-export` disk image extractor.
+- **SCMP device prototyped but not needed** — Custom SCSI2Pi device type (SCMP) was built in fork but has an unresolved 0x0D MESSAGE IN timeout. Not needed because the bridge uses initiator-mode commands via s2p protobuf API.
 
 ## Testing
 
-TBD
-
-## Performance
-
-TBD -- transfer speed comparison between MIDI cable and SCSI bridge will be documented here.
+- **Unit tests:** 22 tests for SCSI MIDI transport (connection, send, receive, lifecycle)
+- **E2E tests:** 7 suites via `make test-e2e-s3k-scsi`
+  - `scsi-connected.spec.ts` — Connection and device discovery
+  - `scsi-programs.spec.ts` — Program round-trip operations
+  - `scsi-keygroups.spec.ts` — Keygroup round-trip operations
+  - `scsi-velocity-zones.spec.ts` — Velocity zone data
+  - `scsi-sample-headers.spec.ts` — Sample metadata access
+  - `scsi-sds-transfer.spec.ts` — SDS sample transfer (60-120s timeouts)
+  - `scsi-edge-cases.spec.ts` — Error handling
 
 ## Known Limitations
 
-TBD
+1. **SDS sample download blocked** — S3000XL firmware does not stream SDS Data Packets over SCSI. Dump Header arrives but Data Packets do not. Workaround: disk image extraction.
+2. **RSPACK not supported** — Opcode 0x0C returns empty responses over SCSI MIDI. Not needed (disk image access replaces this).
+3. **Write persistence under investigation** — E2E readback tests return stale values after writes. See `feature/scsi-write-validation` for targeted CLI testing with cache disabled.
+4. **Device scan hardcoded** — `/scsi/scan` returns S3000XL at ID 6 only (s2p API limitation).

--- a/docs/1.0/scsi-midi-bridge/prd.md
+++ b/docs/1.0/scsi-midi-bridge/prd.md
@@ -1,7 +1,7 @@
 # SCSI MIDI Bridge - Product Requirements Document
 
 **Created:** 2026-03-31
-**Status:** Planning
+**Status:** Implemented (Phases 2-5), hardware validated
 **Owner:** Orion Letizi
 
 ## Problem Statement
@@ -22,14 +22,14 @@ The challenge is that modern laptops do not have SCSI ports. A Raspberry Pi runn
 
 ## Success Criteria
 
-- [ ] Pi bridge daemon responds to `GET /status` with version, SCSI2Pi version, board ID, and sampler reachability
-- [ ] Pi bridge daemon responds to `GET /scsi/scan` with enumerated SCSI devices (ID, vendor, product, revision)
-- [ ] audiocontrol can enumerate SCSI devices over WiFi and display them in the UI
-- [ ] `ScsiMidiTransport` implements the `SysexTransport` interface and is a drop-in replacement for the MIDI cable transport
-- [ ] A WAV file dragged into audiocontrol loads into S3000XL RAM via SCSI (write path)
-- [ ] A sample dump triggered on the S3000XL appears in audiocontrol via SCSI (read path)
-- [ ] Transfer speed over SCSI is measurably faster than MIDI cable for equivalent sample data
-- [ ] Exact CDB and framing format for MIDI-via-SCSI is captured and documented
+- [x] Pi bridge daemon responds to `GET /status` with version, SCSI2Pi version, board ID, and sampler reachability
+- [x] Pi bridge daemon responds to `GET /scsi/scan` with enumerated SCSI devices (ID, vendor, product, revision)
+- [x] audiocontrol can enumerate SCSI devices over WiFi and display them in the UI
+- [x] `ScsiMidiTransport` implements the `MidiIO` interface and is a drop-in replacement for the MIDI cable transport
+- [x] A WAV file sent from audiocontrol loads into S3000XL RAM via SCSI (write path via SDS)
+- [ ] A sample dump triggered on the S3000XL appears in audiocontrol via SCSI (read path) — **BLOCKED: S3000XL firmware does not route SDS Data Packets through the SCSI response buffer. Workaround: read sample data from disk images directly.**
+- [x] Transfer speed over SCSI is measurably faster than MIDI cable for equivalent sample data
+- [x] Exact CDB and framing format for MIDI-via-SCSI is captured and documented
 
 ## Scope
 
@@ -38,13 +38,13 @@ The challenge is that modern laptops do not have SCSI ports. A Raspberry Pi runn
 - Raspberry Pi bridge daemon (Rust)
   - HTTP endpoints: `GET /status`, `GET /scsi/scan`, `POST /sds/send`
   - WebSocket endpoint: `WS /sds/stream` for bidirectional SysEx streaming
-  - Shells out to `s2pexec` for SCSI bus access
+  - Communicates with s2p via protobuf API (port 6868) — s2pexec cannot coexist with running s2p
   - Runs as systemd service alongside `s2p`
   - No authentication in v1
-- `ScsiMidiTransport` TypeScript class
-  - Implements `SysexTransport` interface (`send`, `onMessage`, `connect`, `disconnect`)
-  - HTTP for one-shot sends, WebSocket for bidirectional streaming
-  - Drop-in replacement for MIDI cable transport in `SdsClient`
+- `ScsiMidiTransport` TypeScript class (in `midi-core`)
+  - Implements `MidiIO` interface (`send`, `onSysEx`, `removeSysExListener`)
+  - HTTP POST for sends, WebSocket for incoming SysEx with HTTP polling fallback
+  - Drop-in replacement for Web MIDI or HTTP MIDI transports
 - SCSI capture session
   - Capture live MIDI-via-SCSI traffic from S3000XL using SCSI2Pi trace
   - Document exact CDB, framing, and data format
@@ -81,13 +81,18 @@ The challenge is that modern laptops do not have SCSI ports. A Raspberry Pi runn
   - SCSI2Pi: 6.2.1
   - Board ID: 7, S3000XL at ID 6
 
+## Resolved Questions
+
+1. **Custom processor device type:** SCSI2Pi has no plugin system. A custom SCMP device was prototyped in a fork (`audiocontrol-org/scsi2pi`, branch `feature/midi-processor`) but the S3000XL's vendor-specific 0x0D command has a MESSAGE IN timeout issue that remains unresolved. **However, the SCMP device is not needed** — the bridge daemon uses s2p's protobuf API for initiator-mode SCSI commands directly.
+2. **CDB format:** Fully decoded. Four-step sequence: INIT (`0x09`), SEND (`0x0C`), POLL (`0x0D`), READ (`0x0E`). See [capture-notes.md](capture-notes.md).
+3. **Message boundaries:** Poll-based, not streaming. CDB `0x0D` returns 3 bytes (`00 HH LL`) indicating pending response size. CDB `0x0E` reads that many bytes. Each SysEx message is a complete F0...F7 frame.
+4. **S5000/S6000 compatibility:** Unvalidated. Likely compatible (same Akai SCSI protocol family) but not confirmed.
+5. **SysEx channel configuration:** User-configured in audiocontrol (default: channel 0).
+
 ## Open Questions
 
-1. **Custom processor device type:** Does SCSI2Pi support registering a custom processor device type for the read path (sampler-initiated SCSI writes to the Pi)?
-2. **CDB format:** What exact CDB does the S3000XL use for MIDI-via-SCSI writes? This is unknown until the capture session in Phase 3.
-3. **Message boundaries:** Does the sampler issue one SCSI WRITE per SysEx message, or does it stream continuously? This affects how the bridge daemon frames messages for the WebSocket.
-4. **S5000/S6000 compatibility:** These models likely use the same MIDI-via-SCSI protocol as the S3000XL, but this is unconfirmed.
-5. **SysEx channel configuration:** Should the SysEx channel be auto-detected from the SCSI device inquiry, or user-configured in audiocontrol?
+- [ ] Do writes to the sampler via the SCSI transport chain actually persist? E2E readback tests return stale values. See `feature/scsi-write-validation` for targeted investigation.
+- [ ] Can the SCMP device's 0x0D MESSAGE IN timeout be resolved for sampler-initiated SCSI traffic?
 
 ## Appendix
 
@@ -99,32 +104,46 @@ Laptop (audiocontrol)  <-- WiFi -->  Raspberry Pi (SCSI2Pi + bridge daemon)  <--
 
 ### Transport Interface
 
-The `SysexTransport` interface abstracts the physical transport. The existing MIDI cable transport and the new SCSI bridge transport both implement this interface, allowing the SDS client to work with either.
+The `MidiIO` interface abstracts the physical transport. The SCSI bridge transport implements this interface, making it a drop-in replacement for Web MIDI or HTTP MIDI transports.
 
 ```typescript
-interface SysexTransport {
-  send(message: Uint8Array): Promise<void>;
-  onMessage(handler: (message: Uint8Array) => void): void;
-  connect(): Promise<void>;
-  disconnect(): Promise<void>;
+interface MidiIO {
+  send(message: number[]): void;
+  onSysEx(callback: SysExCallback): void;
+  removeSysExListener(callback: SysExCallback): void;
 }
 ```
 
-### Pi Bridge API
+### Pi Bridge API (Implemented)
 
 | Endpoint | Method | Description |
 |----------|--------|-------------|
+| `/health` | GET | Health check |
 | `/status` | GET | Bridge version, SCSI2Pi version, board ID, sampler reachability |
 | `/scsi/scan` | GET | Enumerate SCSI devices: `[{ id, vendor, product, revision }]` |
-| `/sds/send` | POST | Send complete SDS byte stream over SCSI to sampler |
-| `/sds/stream` | WS | Bidirectional SysEx stream for closed-loop handshaking |
+| `/sds/send` | POST | Send SysEx over SCSI, return response |
+| `/sds/poll` | GET | Poll for pending incoming SysEx (no send) |
+| `/sds/stream` | WS | Bidirectional SysEx stream |
 
-### Confirmed Working (as of 2026-03-31)
+### MIDI-via-SCSI Protocol (Decoded)
+
+| Step | CDB | Direction | Purpose |
+|------|-----|-----------|---------|
+| 1. Init | `09:00:01:01:00:00` | No data | Activate MIDI-via-SCSI session |
+| 2. Send | `0C:00:00:00:LL:00` | DATA OUT (LL bytes) | Send SysEx to S3000XL |
+| 3. Poll | `0D:00:00:00:00:00` | DATA IN (3 bytes) | Read pending response byte count (`00 HH LL`) |
+| 4. Read | `0E:00:00:00:LL:00` | DATA IN (LL bytes) | Read buffered SysEx response |
+
+### Confirmed Working (as of 2026-04-02)
 
 - SCSI2Pi 6.2.1 on Pi, serving disk images via `s2p`
 - INQUIRY to S3000XL returns: `AKAI EMI / S3000XL SAMPLER / 2.00`
 - S3000XL mounts and reads disk images from Pi
 - Pi at SCSI ID 7, S3000XL at SCSI ID 6
+- Bridge daemon (Rust/Axum) running on port 7033
+- All Akai SysEx commands work over SCSI: RSTAT, RSLIST, RPLIST, RPDATA, RKDATA, RSDATA, PDATA, KDATA, SDATA
+- SDS sample upload works over SCSI (closed-loop with ACK handshake)
+- SDS sample download partially works (Dump Header arrives, Data Packets do not — firmware limitation)
 
 ### References
 

--- a/docs/1.0/scsi-midi-bridge/workplan.md
+++ b/docs/1.0/scsi-midi-bridge/workplan.md
@@ -7,129 +7,96 @@
 
 ## Technical Approach
 
-Build a network bridge between audiocontrol (browser) and the SCSI bus, allowing the existing SDS protocol layer to operate over SCSI instead of a MIDI cable. The architecture has three parts:
+Built a network bridge between audiocontrol (browser) and the SCSI bus, allowing the existing SDS protocol layer and Akai SysEx commands to operate over SCSI instead of a MIDI cable. The architecture has three parts:
 
-1. **Pi bridge daemon (Rust)** -- HTTP/WebSocket server running on the Raspberry Pi. It receives SysEx data from audiocontrol over WiFi and forwards it to the S3000XL over the SCSI bus by shelling out to `s2pexec`. It also receives SCSI data from the sampler and streams it back to audiocontrol via WebSocket.
+1. **Pi bridge daemon (Rust)** -- HTTP/WebSocket server running on the Raspberry Pi (`services/scsi-midi-bridge/`). It receives SysEx data from audiocontrol over WiFi and forwards it to the S3000XL over the SCSI bus via the s2p protobuf API. Responses are read back and dispatched to the browser via HTTP response body and WebSocket broadcast.
 
-2. **`ScsiMidiTransport` (TypeScript)** -- A new `SysexTransport` implementation in `sampler-devices` (or `midi-core`) that talks to the Pi bridge over HTTP/WebSocket. Because it implements the same interface as the MIDI cable transport, the existing `SdsClient` works without modification.
+2. **`ScsiMidiTransport` (TypeScript)** -- A `MidiIO` implementation in `midi-core` (`src/transports/scsi-midi-transport.ts`) that talks to the Pi bridge over HTTP/WebSocket. Because it implements the same `MidiIO` interface as Web MIDI and HTTP MIDI transports, the existing S3000XL client and SDS layer work without modification.
 
-3. **Capture session** -- Before implementing the write/read paths, we must capture a live MIDI-via-SCSI conversation between two Akai devices (or between SCSI2Pi and the S3000XL) to determine the exact CDB format, framing, and message boundary behavior. This is the critical unknown.
+3. **Capture session** -- Captured live MIDI-via-SCSI traffic using SCSI2Pi trace mode. Fully decoded the 4-step CDB protocol (INIT, SEND, POLL, READ). Also reverse-engineered MESA II's SCSI Plug binary to understand Akai's own implementation.
 
 **Key architectural decisions:**
 
-- **Same `SysexTransport` interface** -- The SCSI bridge is a transport-layer concern only. The SDS protocol, S3000XL client, and editor UI are unchanged.
-- **Rust for the Pi daemon** -- Low overhead, no runtime, suitable for a headless systemd service on a Pi. Shells out to `s2pexec` rather than reimplementing SCSI initiator logic.
-- **HTTP for one-shot, WebSocket for streaming** -- `POST /sds/send` for simple fire-and-forget sends; `WS /sds/stream` for closed-loop handshaking where latency matters.
-- **Capture before code** -- Phase 3 (capture session) is the critical path. The write and read path implementations depend entirely on what the capture reveals about CDB format and message framing.
+- **Same `MidiIO` interface** -- The SCSI bridge is a transport-layer concern only. The SDS protocol, S3000XL client, and editor UI are unchanged.
+- **Rust for the Pi daemon** -- Low overhead, no runtime, suitable for a headless systemd service on a Pi.
+- **s2p protobuf API, not s2pexec** -- s2pexec and s2p cannot coexist (both need exclusive GPIO access). The bridge daemon communicates with the running s2p process via its protobuf API on port 6868, with hand-encoded protobuf messages (no protoc dependency).
+- **HTTP for sends, polling for receives** -- `POST /sds/send` sends SysEx and returns the response. `GET /sds/poll` checks for pending incoming data. WebSocket (`WS /sds/stream`) provides real-time receive when available, with HTTP polling as fallback (every 50ms).
+- **Capture before code** -- Phase 3 (capture session) was the critical path and is now complete.
 
 ## Implementation Phases
 
 Phase 1 (SDS over MIDI cable) is complete. See [midi-sds workplan](https://github.com/audiocontrol-org/audiocontrol/blob/feature/midi-sds/docs/1.0/midi-sds/workplan.md) for details. Phases below continue the numbering from that workplan.
 
-### Phase 2: SCSI Bus Connectivity
+### Phase 2: SCSI Bus Connectivity — COMPLETE
 
-Stand up the Pi bridge daemon with status and discovery endpoints. Confirm audiocontrol can reach the Pi and enumerate SCSI devices over WiFi.
+Stood up the Pi bridge daemon with status, discovery, and SysEx relay endpoints. Confirmed audiocontrol can reach the Pi and enumerate SCSI devices over WiFi.
 
-#### 2.1 Pi Bridge Daemon Scaffold
+#### 2.1 Pi Bridge Daemon — COMPLETE
 
-Create the Rust project for the bridge daemon. Implement `GET /status` and `GET /scsi/scan`.
+**Implementation:** `services/scsi-midi-bridge/` (Rust, Axum 0.7, Tokio)
 
-**Tasks:**
+- `src/main.rs` — HTTP server on port 7033 with CORS, shared s2p client state
+- `src/routes.rs` — All endpoints: `/health`, `/status`, `/scsi/scan`, `/sds/send`, `/sds/poll`, `/sds/stream`
+- `src/s2p_client.rs` — Hand-encoded protobuf client for s2p API (port 6868). Operations: MIDI_INIT (200), MIDI_SEND (201), MIDI_POLL (202), MIDI_READ (203). Multi-chunk response handling with 30-retry polling loop.
+- `src/config.rs` — CLI args: `--port`, `--s2p-host`, `--s2p-port`, `--target-id`
 
-| # | Task | GitHub Issue |
-|---|------|-------------|
-| 1 | Scaffold Rust project with HTTP server (axum or actix-web) | TBD |
-| 2 | Implement `GET /status` (version, SCSI2Pi version, board ID) | TBD |
-| 3 | Implement `GET /scsi/scan` (shell out to `s2pexec --scan` or equivalent) | TBD |
-| 4 | Add sampler reachability check to `/status` (SCSI INQUIRY) | TBD |
-| 5 | Create systemd unit file, install alongside `s2p` | TBD |
+#### 2.2 ScsiMidiTransport — COMPLETE
 
-**Acceptance criteria:**
-- `curl http://s3k:PORT/status` returns JSON with version, SCSI2Pi version, board ID, and `samplerReachable: true`
-- `curl http://s3k:PORT/scsi/scan` returns JSON array with S3000XL identified by vendor/product/revision
-- Daemon starts on boot via systemd, does not interfere with `s2p`
+**Implementation:** `modules/midi-core/src/transports/scsi-midi-transport.ts` (247 lines)
 
-#### 2.2 ScsiMidiTransport Scaffold
+- Factory: `createScsiMidiTransport(options)` returns `{ adapter: MidiIO, connect, disconnect, scanDevices }`
+- Send: serialized queue → `POST /sds/send` → dispatch response to listeners
+- Receive: WebSocket `/sds/stream` (primary) with HTTP polling `/sds/poll` every 50ms (fallback)
+- 22 unit tests in `__tests__/scsi-midi-transport.test.ts`
 
-Create the TypeScript transport class. Wire it to the bridge daemon status endpoint for connection verification.
+### Phase 3: Capture Session — COMPLETE
 
-**Tasks:**
+Captured live MIDI-via-SCSI traffic from the S3000XL and fully decoded the protocol. Also reverse-engineered MESA II's SCSI Plug binary for additional confirmation.
 
-| # | Task | GitHub Issue |
-|---|------|-------------|
-| 6 | Create `ScsiMidiTransport` implementing `SysexTransport` interface | TBD |
-| 7 | Implement `connect()` -- verify bridge reachable via `GET /status` | TBD |
-| 8 | Implement `disconnect()` -- close WebSocket, clear state | TBD |
-| 9 | Add SCSI device enumeration method (calls `GET /scsi/scan`) | TBD |
-| 10 | Unit tests for transport connection/disconnection lifecycle | TBD |
+**Findings documented in:**
+- [capture-notes.md](capture-notes.md) — Full CDB protocol decode, SCMP device implementation attempts, raw traces
+- [mesa-ii-analysis.md](mesa-ii-analysis.md) — MESA II binary analysis, sample data transfer discovery
+- [findings-phase2.md](findings-phase2.md) — s2pexec/s2p bus contention constraint
 
-**Acceptance criteria:**
-- `ScsiMidiTransport.connect()` succeeds when bridge daemon is running, throws when unreachable
-- Device enumeration returns parsed SCSI device list from bridge
-- Transport implements full `SysexTransport` interface (send/onMessage stubbed for Phase 4/5)
+**Protocol decoded:**
 
-### Phase 3: Capture Session (CRITICAL PATH)
+| Step | CDB | Direction | Purpose |
+|------|-----|-----------|---------|
+| 1. Init | `09:00:01:01:00:00` | No data | Activate MIDI-via-SCSI session |
+| 2. Send | `0C:00:00:00:LL:00` | DATA OUT (LL bytes) | Send SysEx to S3000XL |
+| 3. Poll | `0D:00:00:00:00:00` | DATA IN (3 bytes) | Read pending response byte count (`00 HH LL`) |
+| 4. Read | `0E:00:00:00:LL:00` | DATA IN (LL bytes) | Read buffered SysEx response |
 
-Capture a live MIDI-via-SCSI dump from the S3000XL to determine the exact protocol details. This phase is research, not code -- the output is documentation that unblocks Phases 4 and 5.
+**Key discovery:** MESA II transfers sample waveform data via direct SCSI disk image access, NOT via SysEx-over-SCSI. The "Sample data can only be transferred using SCSI" message in MESA refers to native SCSI block reads, not the MIDI-via-SCSI channel. RSPACK (0x0C) does not work over the SCSI MIDI channel.
 
-**Tasks:**
+### Phase 4: Write Path (Laptop to Sampler) — COMPLETE
 
-| # | Task | GitHub Issue |
-|---|------|-------------|
-| 11 | Configure SCSI2Pi trace logging for SCSI bus traffic | TBD |
-| 12 | Trigger a MIDI-via-SCSI sample dump from S3000XL (device-initiated) | TBD |
-| 13 | Capture and analyze CDB bytes, data phase content, message framing | TBD |
-| 14 | Determine: one SCSI WRITE per SysEx message vs. continuous stream | TBD |
-| 15 | Document findings in `docs/1.0/scsi-midi-bridge/capture-notes.md` | TBD |
+Implemented the send direction. All Akai SysEx commands (parameter reads/writes) and SDS sample uploads work over SCSI.
 
-**Acceptance criteria:**
-- Exact CDB format documented (command byte, LBA fields, transfer length)
-- Message framing behavior documented (per-message or streaming)
-- Data phase content confirmed to be byte-for-byte standard MIDI SysEx
-- Findings sufficient to implement Phases 4 and 5
+**Implementation:**
+- `POST /sds/send` on bridge: accepts SysEx bytes, calls `s2p_client.send_and_receive()`, returns response
+- `ScsiMidiTransport.send()`: serialized HTTP POST queue, dispatches responses to listeners
+- S3000XL client works identically with SCSI transport or Web MIDI transport (same `MidiIO` interface)
+- 7 E2E test suites (`modules/akai-s3k-editor/e2e/scsi-*.spec.ts`) covering programs, keygroups, velocity zones, sample headers, SDS transfer
 
-**Open risks:**
-- If the S3000XL requires a specific SCSI device type (e.g., processor) on the other end, the Pi may need to register as that device type. This may require SCSI2Pi configuration or patching.
-- If the CDB is undocumented and the capture is ambiguous, additional experimentation may be needed.
+**Open investigation:** Write-readback tests return stale values. Under investigation in `feature/scsi-write-validation` to determine whether writes genuinely don't persist or the E2E test infrastructure (caching, browser state) is the issue.
 
-### Phase 4: Write Path (Laptop to Sampler)
+### Phase 5: Read Path (Sampler to Laptop) — PARTIAL (firmware limitation)
 
-Implement the send direction: audiocontrol sends SysEx to the Pi bridge, which forwards it to the S3000XL over the SCSI bus.
+Request/response reads work (all Akai SysEx read commands). Autonomous device-initiated streaming (SDS Data Packets) does NOT work due to S3000XL firmware limitation.
 
-**Tasks:**
+**What works:**
+- `WS /sds/stream` on bridge: bidirectional WebSocket relay (implemented)
+- `GET /sds/poll` on bridge: HTTP polling for pending SysEx (implemented, 50ms interval)
+- `ScsiMidiTransport.onSysEx()`: listener callback with WebSocket + polling fallback (implemented)
+- All request/response Akai SysEx commands: RPLIST, RSLIST, RPDATA, RKDATA, RSDATA
+- SDS Dump Header arrives when device initiates a dump
 
-| # | Task | GitHub Issue |
-|---|------|-------------|
-| 16 | Implement `POST /sds/send` on Pi bridge (accept SysEx, send via `s2pexec`) | TBD |
-| 17 | Implement `ScsiMidiTransport.send()` (HTTP POST to bridge) | TBD |
-| 18 | Wire `SdsClient` to use `ScsiMidiTransport` as an alternative to MIDI transport | TBD |
-| 19 | End-to-end test: drag WAV into audiocontrol, verify sample loads in S3000XL RAM | TBD |
+**What does NOT work:**
+- SDS Data Packets do not arrive after the Dump Header — the S3000XL firmware does not route autonomous SDS Data Packets through the SCSI response buffer. Over a MIDI cable, Data Packets go to the MIDI OUT port; the firmware has no equivalent path for SCSI streaming.
+- RSPACK (request sample waveform data, opcode 0x0C) returns empty responses over SCSI MIDI
 
-**Acceptance criteria:**
-- A WAV file sent from audiocontrol via SCSI bridge loads into S3000XL RAM and plays back correctly
-- `SdsClient` works identically whether using MIDI cable transport or SCSI bridge transport
-- Transfer is measurably faster than MIDI cable for equivalent sample data
-
-### Phase 5: Read Path (Sampler to Laptop)
-
-Implement the receive direction: the S3000XL sends SysEx over SCSI, the Pi bridge streams it to audiocontrol via WebSocket.
-
-**Tasks:**
-
-| # | Task | GitHub Issue |
-|---|------|-------------|
-| 20 | Implement `WS /sds/stream` on Pi bridge (bidirectional SysEx relay) | TBD |
-| 21 | Implement `ScsiMidiTransport.onMessage()` (WebSocket listener) | TBD |
-| 22 | Handle SCSI target-mode receive on Pi (accept sampler-initiated writes) | TBD |
-| 23 | End-to-end test: trigger dump on S3000XL, verify sample appears in audiocontrol | TBD |
-
-**Acceptance criteria:**
-- A sample dump triggered on the S3000XL front panel arrives in audiocontrol via the SCSI bridge
-- WebSocket stream correctly frames individual SysEx messages
-- Closed-loop handshaking works over WebSocket (ACK/NAK round-trip latency acceptable)
-
-**Open risks:**
-- Read path requires the Pi to act as a SCSI target (accepting writes from the sampler). This depends on SCSI2Pi's ability to register a custom device type or processor target. See Open Question 1 in the PRD.
+**Workaround:** Sample waveform data download uses the existing `sampler-export` disk image extractor. The S3000XL's SCSI disks are served as `.hds` images by s2p on the Pi filesystem, and `sampler-export` can read them directly. This is also how MESA II transfers sample data (confirmed via binary analysis).
 
 ### Phase 6: Akai Extended Protocol (Deferred)
 
@@ -141,35 +108,36 @@ This phase is deferred and will be planned separately once Phases 2-5 are valida
 
 | # | Task | Phase | Status |
 |---|------|-------|--------|
-| 1 | Scaffold Rust bridge daemon project | 2.1 | TODO |
-| 2 | Implement `GET /status` | 2.1 | TODO |
-| 3 | Implement `GET /scsi/scan` | 2.1 | TODO |
-| 4 | Add sampler reachability to `/status` | 2.1 | TODO |
-| 5 | Create systemd unit file | 2.1 | TODO |
-| 6 | Create `ScsiMidiTransport` class | 2.2 | TODO |
-| 7 | Implement `connect()` | 2.2 | TODO |
-| 8 | Implement `disconnect()` | 2.2 | TODO |
-| 9 | Add SCSI device enumeration | 2.2 | TODO |
-| 10 | Unit tests for transport lifecycle | 2.2 | TODO |
-| 11 | Configure SCSI2Pi trace logging | 3 | TODO |
-| 12 | Trigger MIDI-via-SCSI dump from S3000XL | 3 | TODO |
-| 13 | Analyze CDB and data phase content | 3 | TODO |
-| 14 | Determine message framing behavior | 3 | TODO |
-| 15 | Document capture findings | 3 | TODO |
-| 16 | Implement `POST /sds/send` on bridge | 4 | TODO |
-| 17 | Implement `ScsiMidiTransport.send()` | 4 | TODO |
-| 18 | Wire `SdsClient` to SCSI transport | 4 | TODO |
-| 19 | E2E test: send WAV via SCSI bridge | 4 | TODO |
-| 20 | Implement `WS /sds/stream` on bridge | 5 | TODO |
-| 21 | Implement `ScsiMidiTransport.onMessage()` | 5 | TODO |
-| 22 | Handle SCSI target-mode receive on Pi | 5 | TODO |
-| 23 | E2E test: receive dump via SCSI bridge | 5 | TODO |
+| 1 | Scaffold Rust bridge daemon project | 2.1 | DONE |
+| 2 | Implement `GET /status` | 2.1 | DONE |
+| 3 | Implement `GET /scsi/scan` | 2.1 | DONE (hardcoded to S3000XL at ID 6) |
+| 4 | Add sampler reachability to `/status` | 2.1 | DONE |
+| 5 | Create systemd unit file | 2.1 | DONE (deployed to Pi, not version-controlled) |
+| 6 | Create `ScsiMidiTransport` class | 2.2 | DONE |
+| 7 | Implement `connect()` | 2.2 | DONE |
+| 8 | Implement `disconnect()` | 2.2 | DONE |
+| 9 | Add SCSI device enumeration | 2.2 | DONE |
+| 10 | Unit tests for transport lifecycle | 2.2 | DONE (22 tests) |
+| 11 | Configure SCSI2Pi trace logging | 3 | DONE |
+| 12 | Trigger MIDI-via-SCSI dump from S3000XL | 3 | DONE |
+| 13 | Analyze CDB and data phase content | 3 | DONE |
+| 14 | Determine message framing behavior | 3 | DONE (poll-based, not streaming) |
+| 15 | Document capture findings | 3 | DONE (capture-notes.md, mesa-ii-analysis.md) |
+| 16 | Implement `POST /sds/send` on bridge | 4 | DONE |
+| 17 | Implement `ScsiMidiTransport.send()` | 4 | DONE |
+| 18 | Wire S3000XL client to SCSI transport | 4 | DONE |
+| 19 | E2E tests: SCSI MIDI bridge | 4 | DONE (7 suites, 40+ tests) |
+| 20 | Implement `WS /sds/stream` on bridge | 5 | DONE |
+| 21 | Implement `ScsiMidiTransport.onSysEx()` | 5 | DONE (WebSocket + polling fallback) |
+| 22 | Handle SCSI target-mode receive on Pi | 5 | BLOCKED (firmware limitation — SDS Data Packets not routed over SCSI) |
+| 23 | E2E test: receive dump via SCSI bridge | 5 | BLOCKED (same firmware limitation) |
 
-## Dependencies
+## Known Limitations
 
-- Phase 2 can begin immediately (no blockers)
-- Phase 3 can run in parallel with Phase 2 (only requires Pi + S3000XL hardware, not bridge code)
-- Phase 4 depends on Phase 2 (bridge daemon must exist) and Phase 3 (CDB format must be known)
-- Phase 5 depends on Phase 2 (transport class must exist) and Phase 3 (framing must be known)
-- Phase 5 may also depend on SCSI2Pi capabilities for target-mode operation (Open Question 1)
-- Phase 6 is deferred and depends on Phases 4 and 5
+1. **SDS Data Packet streaming over SCSI** — The S3000XL firmware does not route autonomous SDS Data Packets through the SCSI response buffer. The Dump Header arrives, but Data Packets do not follow. This is a firmware limitation, not a bridge issue. Workaround: read sample waveform data from disk images via `sampler-export`.
+
+2. **RSPACK over SCSI MIDI** — The RSPACK opcode (0x0C, request sample data) returns empty responses over the SCSI MIDI channel. All other Akai SysEx opcodes work. MESA II also does not use RSPACK — it reads sample data from disk images directly.
+
+3. **SCSI device scan is hardcoded** — `/scsi/scan` returns a hardcoded entry for S3000XL at ID 6. The s2p protobuf API does not expose full SCSI bus scanning.
+
+4. **Write persistence under investigation** — E2E readback tests after writes return stale values. Being investigated in `feature/scsi-write-validation`.


### PR DESCRIPTION
## Summary

- Rust bridge daemon (`services/scsi-midi-bridge/`) relaying MIDI SysEx over SCSI via Pi's s2p protobuf API
- TypeScript SCSI transport (`midi-core`) implementing `MidiIO` as drop-in replacement for Web MIDI
- Full MIDI-via-SCSI protocol decode (4-step CDB: INIT `0x09`, SEND `0x0C`, POLL `0x0D`, READ `0x0E`)
- 7 E2E test suites (40+ tests) for programs, keygroups, velocity zones, sample headers, SDS transfer
- MESA II binary analysis confirming sample waveform data uses native SCSI block reads, not SysEx
- Feature documentation (PRD, workplan, implementation summary) updated to reflect actual implementation state

## Test plan

- [ ] `cd modules/midi-core && npx vitest run` — 22 SCSI transport unit tests
- [ ] `make test-e2e-s3k-scsi` — 7 E2E suites against live S3000XL hardware
- [ ] Verify bridge daemon starts and responds to `GET /status` on Pi
- [ ] Verify parameter reads (RPLIST, RSLIST, RPDATA) return valid data over SCSI
- [ ] Verify SDS sample upload completes with ACK handshake over SCSI