### PR TITLE
feat: Edit Sample for drum kits + E2E coverage to 145/229

### DIFF
--- a/modules/roland-sxx0-editor/src/components/library/SampleBundlePreviewPanel.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/SampleBundlePreviewPanel.tsx
@@ -49,6 +49,8 @@ interface SampleBundlePreviewPanelProps {
   preloadedManifest?: SampleYaml | null;
   onImport?: () => void;
   onEditKit?: () => void;
+  /** Callback to open the sample editor on the kit's source audio */
+  onOpenSampleEditor?: () => void;
 }
 
 // =========================================================================
@@ -160,6 +162,7 @@ export function SampleBundlePreviewPanel({
   preloadedManifest,
   onImport,
   onEditKit,
+  onOpenSampleEditor,
 }: SampleBundlePreviewPanelProps): JSX.Element {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -415,6 +418,15 @@ export function SampleBundlePreviewPanel({
           {onEditKit && bundle && bundle.source && bundle.slices && (
             <button onClick={onEditKit} className="w-full ac-btn ac-btn-secondary">
               Edit Kit
+            </button>
+          )}
+          {onOpenSampleEditor && bundle && bundle.source && (
+            <button
+              onClick={onOpenSampleEditor}
+              className="w-full ac-btn ac-btn-ghost"
+              data-testid="edit-sample-button"
+            >
+              Edit Sample
             </button>
           )}
           {onImport && (

--- a/modules/roland-sxx0-editor/src/lib/library-drumkits.ts
+++ b/modules/roland-sxx0-editor/src/lib/library-drumkits.ts
@@ -293,6 +293,29 @@ export async function loadDrumKitSource(
 }
 
 /**
+ * Save updated source audio back to a v2 drum kit bundle.
+ * Overwrites the existing source WAV file.
+ */
+export async function saveDrumKitSource(
+  directoryHandle: StorageDirectoryHandle,
+  kitName: string,
+  sourceFilename: string,
+  samples: Int16Array,
+  sampleRate: number,
+  path: string[] = []
+): Promise<void> {
+  const kitDir = await getNestedDirectory(directoryHandle, [
+    'library', 's330', 'drum-kits', ...path, kitName
+  ]);
+
+  const wavBlob = createWavBlobFromSamples(samples, sampleRate);
+  const wavHandle = await kitDir.getFileHandle(sourceFilename, { create: true });
+  const writable = await wavHandle.createWritable();
+  await writable.write(await wavBlob.arrayBuffer());
+  await writable.close();
+}
+
+/**
  * Update the slice definitions and optionally kit config in an existing v2 drum kit.
  */
 export async function updateDrumKitSlices(

--- a/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
+++ b/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
@@ -45,7 +45,7 @@ import {
   listSets, listDrumKits, listIndividualTones, listIndividualPatches,
   listIndividualTonesTree, listIndividualPatchesTree, listDrumKitsTree,
   listCommonSamplesTree,
-  loadDrumKitBundle, loadDrumKitSource, updateDrumKitSlices,
+  loadDrumKitBundle, loadDrumKitSource, saveDrumKitSource, updateDrumKitSlices,
   loadIndividualTone, loadIndividualToneWavSamples,
   type DrumKitInfo, type LibraryToneInfo, type LibraryPatchInfo, type LibraryTreeNode,
   type StorageDirectoryHandle,
@@ -352,6 +352,30 @@ export function LibraryPage() {
     } finally { setLoading(false); }
   }, [libraryHandle, selection, selectedDrumKitBundle, setLoading, setError]);
 
+  // Open the sample editor on a drum kit's source audio
+  const handleOpenDrumKitInSampleEditor = useCallback(async () => {
+    if (!libraryHandle || !selection || selection.type !== 'drumKit' || !selectedDrumKitBundle) return;
+    const bundle = selectedDrumKitBundle;
+    if (!bundle.source) return;
+
+    setLoading(true, 'Loading source audio...');
+    try {
+      const sourceWav = await loadDrumKitSource(libraryHandle, selection.name!, bundle.source, selection.path);
+      setSampleEditorDialog({
+        open: true,
+        samples: sourceWav.samples,
+        sampleRate: sourceWav.sampleRate,
+        sampleName: bundle.name || selection.name!,
+        origin: { name: selection.name!, type: 'drumKit', path: selection.path },
+      });
+    } catch (err) {
+      console.error('[LibraryPage] Failed to load source audio for sample editor:', err);
+      setError(err instanceof Error ? err.message : 'Failed to load source audio');
+    } finally {
+      setLoading(false);
+    }
+  }, [libraryHandle, selection, selectedDrumKitBundle, setLoading, setError]);
+
   const handleSlicesUpdated = useCallback(async (slices: SliceDefinitionOutput[], kitConfig: { transpose?: number; velocitySensitivity?: number }) => {
     if (!libraryHandle || !sliceEditDialog) return;
     setLoading(true, 'Saving slice changes...');
@@ -535,13 +559,18 @@ export function LibraryPage() {
         const writable = await wavHandle.createWritable();
         await writable.write(wavData);
         await writable.close();
+      } else if (nodeType === 'drumKit') {
+        // Write updated source WAV back to the drum kit directory
+        const bundle = selectedDrumKitBundle;
+        if (!bundle?.source) throw new Error('Cannot save: drum kit has no source file');
+        await saveDrumKitSource(libraryHandle, name, bundle.source, samples, sampleRate, path);
       }
       await handleRefreshLibrary();
     } catch (err) {
       console.error('[LibraryPage] Failed to save edited sample:', err);
       setError(err instanceof Error ? err.message : 'Failed to save edited sample');
     }
-  }, [libraryHandle, sampleEditorDialog, handleRefreshLibrary, setError]);
+  }, [libraryHandle, sampleEditorDialog, selectedDrumKitBundle, handleRefreshLibrary, setError]);
 
   // Handle loop editor save (loop points saved back to library)
   const handleLoopEditorSave = useCallback(async (loopStart: number, loopEnd: number) => {
@@ -700,6 +729,7 @@ export function LibraryPage() {
               preloadedBundle={selectedDrumKitBundle}
               onImport={handleOpenSamplesImport}
               onEditKit={handleEditKit}
+              onOpenSampleEditor={handleOpenDrumKitInSampleEditor}
             />
           ) : selection?.type === 'sample' || selection?.type === 'program' ? (
             <CommonSamplePreviewPanel
@@ -779,6 +809,19 @@ export function LibraryPage() {
           initialSlices={sliceEditDialog.slices}
           initialLabels={sliceEditDialog.slices?.map((s) => s.label).join(',')}
           onSlicesUpdated={(slices) => handleSlicesUpdated(slices, {})}
+          onOpenSampleEditor={() => {
+            const dialog = sliceEditDialog;
+            if (dialog) {
+              setSliceEditDialog(null);
+              setSampleEditorDialog({
+                open: true,
+                samples: dialog.samples,
+                sampleRate: dialog.sampleRate,
+                sampleName: dialog.kitName,
+                origin: { name: dialog.kitName, type: 'drumKit', path: dialog.path },
+              });
+            }
+          }}
         />
       )}
       <ExportToneDialog

--- a/modules/sample-chopper/src/ui/components/SampleChopperDialog.tsx
+++ b/modules/sample-chopper/src/ui/components/SampleChopperDialog.tsx
@@ -99,6 +99,8 @@ export interface SampleChopperDialogProps {
     playbackMode: 'one-shot' | 'gate';
     muteGroups: number[];
   };
+  /** Callback to open the sample editor on the source audio */
+  onOpenSampleEditor?: () => void;
 }
 
 export function SampleChopperDialog({
@@ -116,6 +118,7 @@ export function SampleChopperDialog({
   onSave,
   initialTriggers,
   initialPlaybackConfig,
+  onOpenSampleEditor,
 }: SampleChopperDialogProps): JSX.Element {
   const chopper = useSampleChopper({
     samples,
@@ -792,6 +795,15 @@ export function SampleChopperDialog({
                   )}
                 >
                   Create Drum Kit
+                </button>
+              )}
+              {onOpenSampleEditor && (
+                <button
+                  onClick={onOpenSampleEditor}
+                  className="ac-btn ac-btn-ghost"
+                  data-testid="chopper-edit-sample-button"
+                >
+                  Edit Sample
                 </button>
               )}
               <button onClick={handleClose} className="ac-btn ac-btn-ghost">


### PR DESCRIPTION
## Summary

- Add "Edit Sample" buttons to drum kit preview panel and slice editor, allowing users to open the Sample Editor on a drum kit's source WAV
- E2E test coverage increased from 118 to 145 out of 229 test cases (63%)
- Multiple app bugs found and fixed during testing

## Edit Sample feature

Users can now edit a drum kit's source audio (normalize, trim, reverse, etc.) from two entry points:
- **Info panel**: "Edit Sample" button alongside "Edit Kit" and "Import to Device"
- **Slice editor**: "Edit Sample" button in the footer, closes chopper and opens sample editor

Edits are saved back to `source.wav` in the drum kit directory via new `saveDrumKitSource` function.

## E2E test coverage (since last merge)

| Area | Tests Added |
|------|-------------|
| Tone parameter sync | Original key, TVF resonance/key follow, TVA LFO depth, envelope levels/end point |
| Sample operations | WAV export, WAV import, wave bank B selection (verified on S-550) |
| Tone edge cases | Empty tone slot, unsupported format import, corrupted WAV import |
| Set individual load | Load individual tone/patch from saved set (written, needs hardware verification) |
| Data-testid additions | Import/export dialog fields for reliable E2E targeting |

## App changes

- `SampleBundlePreviewPanel`: "Edit Sample" button for v2 drum kits
- `SampleChopperDialog`: "Edit Sample" button in slice editor footer
- `LibraryPage`: wire drum kit sample editor with load/save paths
- `library-drumkits`: new `saveDrumKitSource` function
- `ImportSampleDialog` + `ToneEditor`: data-testid attributes
- `device-readback-helpers`: added `tva.lfoDepth` field

## Test plan

[Comprehensive test plan](docs/1.0/001-IN-PROGRESS/e2e-integration-tests/comprehensive-test-plan.md) — 145/229 covered, 14 partial, 70 remaining.