### PR TITLE
docs: library-ux cross-editor alignment strategy

### DIFF
--- a/docs/1.0/001-IN-PROGRESS/library-ux/README.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/README.md
@@ -1,0 +1,33 @@
+# Library UX Improvements
+
+**Status:** In Progress
+
+## Documentation
+
+- [PRD](./prd.md) - Product requirements document
+- [Workplan](./workplan.md) - Implementation plan
+
+## Overview
+
+UX polish and improvements for the Roland S-330/S-550 editor Library page. Focus areas include visual hierarchy, interaction feedback, discoverability, and code simplification.
+
+## Key Goals
+
+1. **Clearer visual hierarchy** — Panel focus, empty states, loading states
+2. **Better discoverability** — Drag-and-drop affordances, keyboard shortcuts
+3. **Improved feedback** — Progress indicators, error recovery, confirmations
+4. **Code simplification** — Reduce LibraryPage from 908 lines to <500
+
+## Quick Links
+
+- **Worktree:** `~/work/audiocontrol-work/audiocontrol-library-ux`
+- **Branch:** `feature/library-ux`
+- **Module:** `modules/roland-sxx0-editor`
+
+## Current Status
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| PRD | Draft | Awaiting review |
+| Workplan | Draft | Awaiting PRD approval |
+| Implementation | Not started | - |

--- a/docs/1.0/001-IN-PROGRESS/library-ux/README.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/README.md
@@ -1,6 +1,7 @@
 # Library UX Improvements
 
 **Status:** In Progress
+**Branch:** `feature/library-ux`
 
 ## Documentation
 
@@ -9,25 +10,31 @@
 
 ## Overview
 
-UX polish and improvements for the Roland S-330/S-550 editor Library page. Focus areas include visual hierarchy, interaction feedback, discoverability, and code simplification.
+Align and improve library page UX across both the Roland S-330/S-550 editor and the Akai S3000XL editor. The core problem is implementation divergence: the S3K editor uses the shared `PluginLibraryBrowser` from editor-core, but the Roland editor has its own bespoke three-column layout (908 lines, violating the 500-line guideline). Roland's UX is the more mature implementation and the reference standard.
 
 ## Key Goals
 
-1. **Clearer visual hierarchy** — Panel focus, empty states, loading states
-2. **Better discoverability** — Drag-and-drop affordances, keyboard shortcuts
-3. **Improved feedback** — Progress indicators, error recovery, confirmations
-4. **Code simplification** — Reduce LibraryPage from 908 lines to <500
+1. **Alignment** - Migrate Roland onto `PluginLibraryBrowser`, updating the shared component to match Roland's UX standard
+2. **Code reuse** - Extract shared hooks and patterns to editor-core so both editors benefit
+3. **Code quality** - Reduce Roland's LibraryPage from 908 lines to <500 via hook extraction
+4. **UX polish** - Improve visual hierarchy, interaction feedback, and discoverability in the shared components
 
-## Quick Links
+## Scope
 
-- **Worktree:** `~/work/audiocontrol-work/audiocontrol-library-ux`
-- **Branch:** `feature/library-ux`
-- **Module:** `modules/roland-sxx0-editor`
+- **Both editors:** Roland S-330/S-550 (`roland-sxx0-editor`) and Akai S3000XL (`akai-s3k-editor`)
+- **Shared layer:** `editor-core` PluginLibraryBrowser, plugin interfaces, shared hooks
+- Sets remain device-specific (Roland-only category); vendor-agnostic "Multi" concept deferred
+- Both device-specific and common-area categories shown in the library browser
 
 ## Current Status
 
 | Phase | Status | Notes |
 |-------|--------|-------|
-| PRD | Draft | Awaiting review |
-| Workplan | Draft | Awaiting PRD approval |
-| Implementation | Not started | - |
+| Phase 1: Extract Roland hooks | Not started | Pure refactor, no rendering changes |
+| Phase 2: Upstream to editor-core | Not started | Depends on Phase 1 |
+| Phase 3: Migrate Roland to PluginLibraryBrowser | Not started | Highest risk phase |
+| Phase 4: UX polish on shared components | Not started | Benefits both editors |
+
+## Related Documentation
+
+- [S3K Library Page Conformance](../../s3k-library-page/) - Prior effort that brought S3K to three-column layout (largely complete)

--- a/docs/1.0/001-IN-PROGRESS/library-ux/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/prd.md
@@ -1,0 +1,126 @@
+# Roland S-330/S-550 Library Page UX Improvements
+
+**Created:** 2026-03-30
+**Status:** Draft
+**Owner:** TBD
+
+## Problem Statement
+
+The roland-sxx0-editor Library page provides powerful functionality for managing sampler tones, patches, sets, drum kits, and samples across device memory and the local library. However, the current implementation has UX rough edges that create friction for users:
+
+1. **Visual complexity** — The three-column layout (device memory, library browser, preview panel) can be overwhelming, especially for new users
+2. **Discoverability issues** — Key workflows like drag-and-drop import/export, context menus, and keyboard shortcuts are not immediately obvious
+3. **Feedback gaps** — Long-running operations (import, export, device communication) lack clear progress indication and error recovery paths
+4. **Navigation friction** — Moving between deep library hierarchies and device slots requires many clicks
+5. **Code complexity** — The LibraryPage component is 908 lines, indicating potential for simplification
+
+## User Stories
+
+### Primary Workflows
+
+1. **As a user**, I want to quickly import a tone from my library to the device so I can use it in my music production
+2. **As a user**, I want to export my device patches to the library so I can back them up or organize them
+3. **As a user**, I want to manage my library organization (folders, naming) without losing context of what's on the device
+4. **As a user**, I want to preview library items before importing them to understand what they contain
+5. **As a user**, I want to load and save complete sets so I can switch between different project configurations
+
+### Pain Points to Address
+
+1. **As a user**, I get confused about which panel is focused and where my next action will apply
+2. **As a user**, I don't realize I can drag items between panels until I accidentally discover it
+3. **As a user**, I lose my place in the library tree when switching between categories
+4. **As a user**, I can't easily tell which device slots are empty vs populated
+5. **As a user**, error messages don't help me understand what went wrong or how to fix it
+
+## Success Criteria
+
+### User Experience
+- [ ] New users can complete import/export workflows within 2 interactions
+- [ ] Visual hierarchy clearly indicates focus and available actions
+- [ ] All operations provide clear progress feedback
+- [ ] Error states include actionable recovery suggestions
+- [ ] Keyboard navigation supports all common workflows
+
+### Code Quality
+- [ ] LibraryPage component reduced to <500 lines via extraction
+- [ ] Shared patterns extracted to editor-core where applicable
+- [ ] Test coverage for new/modified components
+- [ ] No regression in existing E2E tests
+
+## Scope
+
+### In Scope
+
+1. **Visual polish**
+   - Panel focus indicators
+   - Empty state designs
+   - Loading states and skeletons
+   - Progress indicators for operations
+
+2. **Interaction improvements**
+   - Drag-and-drop affordances (drop zones, cursor feedback)
+   - Context menu organization and keyboard shortcuts
+   - Breadcrumb navigation for deep hierarchies
+   - Keyboard navigation (arrow keys, Enter, Escape)
+
+3. **Feedback improvements**
+   - Operation progress with cancel support where possible
+   - Error messages with recovery suggestions
+   - Success confirmations for destructive actions
+   - Undo support for reversible operations
+
+4. **Code refactoring**
+   - Extract reusable components
+   - Simplify state management
+   - Improve component composition
+
+### Out of Scope
+
+- New library features (new item types, new operations)
+- Device protocol changes
+- Performance optimization (separate effort if needed)
+- Mobile/responsive layout (desktop-first editor)
+
+## Dependencies and Constraints
+
+### Dependencies
+- editor-core shared components (may need enhancements)
+- Existing library-service.ts APIs
+- Plugin architecture for device-specific behavior
+
+### Constraints
+- Must maintain backwards compatibility with existing library formats
+- Must not break existing E2E tests
+- Must work with both S-330 and S-550 device configurations
+
+## Open Questions
+
+1. Should we conduct user research to identify specific pain points, or proceed with heuristic evaluation?
+2. Are there specific workflows from the S3K editor UX effort that should inform this work?
+3. What is the priority order for the improvements listed above?
+4. Should keyboard shortcuts be customizable?
+
+## Technical Notes
+
+### Current Architecture
+
+The LibraryPage uses a three-column layout:
+- **Left:** DeviceMemoryPanel (tones/patches on device)
+- **Center:** PluginLibraryTreePanel (library browser with tree navigation)
+- **Right:** ItemPreviewPanel / SampleBundlePreviewPanel (preview with actions)
+
+Key hooks and utilities:
+- `useLibraryConnection` — OPFS/native filesystem connection
+- `useLibraryExport` — Export operations to library
+- `useLibraryImportDialogs` — Import dialog state management
+- `useDirectoryOperations` — Folder CRUD operations
+- Plugin architecture — Device-specific item types and behaviors
+
+### Dialogs (11 total)
+- SaveSetDialog, LoadSetDialog
+- ImportLibraryToneDialog, ImportLibraryPatchDialog, ImportSamplesDialog
+- ExportToneDialog, ExportPatchDialog
+- CreateDirectoryDialog, RenameDirectoryDialog, DeleteDirectoryDialog, MoveItemDialog
+- SampleChopperDialog, LoopEditorDialog, SampleEditorDialog
+
+This dialog complexity suggests potential for consolidation or workflow simplification.

--- a/docs/1.0/001-IN-PROGRESS/library-ux/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/prd.md
@@ -1,126 +1,116 @@
-# Roland S-330/S-550 Library Page UX Improvements
+# Library UX Improvements - Product Requirements Document
 
 **Created:** 2026-03-30
-**Status:** Draft
-**Owner:** TBD
+**Updated:** 2026-04-07
+**Status:** Approved
+**Owner:** Orion Letizi
 
 ## Problem Statement
 
-The roland-sxx0-editor Library page provides powerful functionality for managing sampler tones, patches, sets, drum kits, and samples across device memory and the local library. However, the current implementation has UX rough edges that create friction for users:
+Both the Roland S-330/S-550 editor and the Akai S3000XL editor have library pages for managing samples, programs, and device memory. However, the two implementations have diverged:
 
-1. **Visual complexity** — The three-column layout (device memory, library browser, preview panel) can be overwhelming, especially for new users
-2. **Discoverability issues** — Key workflows like drag-and-drop import/export, context menus, and keyboard shortcuts are not immediately obvious
-3. **Feedback gaps** — Long-running operations (import, export, device communication) lack clear progress indication and error recovery paths
-4. **Navigation friction** — Moving between deep library hierarchies and device slots requires many clicks
-5. **Code complexity** — The LibraryPage component is 908 lines, indicating potential for simplification
+1. **Implementation divergence** - The S3K editor uses `PluginLibraryBrowser` from editor-core (the shared component). The Roland editor does NOT - it has its own bespoke three-column layout built from `DeviceMemoryPanel`, `PluginLibraryTreePanel`, and `ItemPreviewPanel`. This means UX improvements must be made twice and drift over time.
+
+2. **Roland LibraryPage complexity** - The Roland editor's `LibraryPage.tsx` is 908 lines (violating the 500-line guideline) with 11+ dialogs managed inline, complex state management, and tightly coupled selection/operation logic.
+
+3. **UX rough edges** - Both editors lack visual polish: empty states are unhelpful, drag-and-drop has no affordances, there are no loading skeletons, keyboard navigation is missing, and progress indicators are minimal.
+
+4. **Roland is the UX reference** - The Roland library page is the more mature implementation and the standard that `PluginLibraryBrowser` was based on. But the shared component has drifted from the reference.
 
 ## User Stories
 
-### Primary Workflows
+### Alignment
 
-1. **As a user**, I want to quickly import a tone from my library to the device so I can use it in my music production
-2. **As a user**, I want to export my device patches to the library so I can back them up or organize them
-3. **As a user**, I want to manage my library organization (folders, naming) without losing context of what's on the device
-4. **As a user**, I want to preview library items before importing them to understand what they contain
-5. **As a user**, I want to load and save complete sets so I can switch between different project configurations
+- As a developer, I want both editors to use the same `PluginLibraryBrowser` component so that UX improvements land in both editors automatically
+- As a developer, I want shared hooks for common patterns (editor dialogs, library data loading) so I don't reimplement the same logic per editor
+- As a developer, I want each editor's LibraryPage under 500 lines so the code is maintainable
 
-### Pain Points to Address
+### UX
 
-1. **As a user**, I get confused about which panel is focused and where my next action will apply
-2. **As a user**, I don't realize I can drag items between panels until I accidentally discover it
-3. **As a user**, I lose my place in the library tree when switching between categories
-4. **As a user**, I can't easily tell which device slots are empty vs populated
-5. **As a user**, error messages don't help me understand what went wrong or how to fix it
+- As a user, I want clear visual hierarchy showing which panel is focused and what actions are available
+- As a user, I want drag-and-drop to be discoverable (grab cursors, drop zone highlights, invalid target indicators)
+- As a user, I want loading skeletons instead of blank panels while data loads
+- As a user, I want progress bars for import/export operations with cancellation support where possible
+- As a user, I want keyboard navigation (arrow keys, Enter, Escape, Delete) for all common workflows
+- As a user, I want empty states that guide me toward the next action instead of showing blank panels
+- As a user, I want error messages that explain what went wrong and how to recover
+
+### Device-Specific
+
+- As a Roland editor user, I want Sets to continue working as a device-specific category in the library browser
+- As an S3K editor user, I want the same visual quality and interaction patterns as the Roland editor
 
 ## Success Criteria
 
-### User Experience
-- [ ] New users can complete import/export workflows within 2 interactions
-- [ ] Visual hierarchy clearly indicates focus and available actions
-- [ ] All operations provide clear progress feedback
-- [ ] Error states include actionable recovery suggestions
-- [ ] Keyboard navigation supports all common workflows
+### Alignment
+- [ ] Roland editor uses `PluginLibraryBrowser` from editor-core (same component as S3K)
+- [ ] Roland `LibraryPage.tsx` is under 500 lines
+- [ ] Shared `useEditorDialogs` hook in editor-core used by both editors
+- [ ] `PluginLibraryBrowser` matches Roland's UX standard (context menus, all category types)
+- [ ] `libraryHandle` prop type widened to accept `StorageDirectoryHandle`
 
-### Code Quality
-- [ ] LibraryPage component reduced to <500 lines via extraction
-- [ ] Shared patterns extracted to editor-core where applicable
-- [ ] Test coverage for new/modified components
-- [ ] No regression in existing E2E tests
+### UX
+- [ ] All panels have focus indicators
+- [ ] Empty states show guidance and action prompts
+- [ ] Loading skeletons shown during async operations
+- [ ] Drag-and-drop has visual affordances (grab cursor, drop zones, invalid targets)
+- [ ] Keyboard navigation works for tree browsing (arrows, Enter, Escape, Delete)
+- [ ] Import/export operations show progress bars
+
+### Regression Safety
+- [ ] All existing Roland E2E tests pass after migration
+- [ ] All existing S3K E2E tests pass
+- [ ] No visual regression in either editor
+- [ ] Sets functionality preserved in Roland editor
 
 ## Scope
 
 ### In Scope
 
-1. **Visual polish**
-   - Panel focus indicators
-   - Empty state designs
-   - Loading states and skeletons
-   - Progress indicators for operations
+**Alignment work:**
+- Extract Roland LibraryPage into hooks (editor dialogs, data loading, selection mapping, operation handlers)
+- Upstream Roland patterns to editor-core (context menu wiring, Sets as CategoryPlugin)
+- Migrate Roland to `PluginLibraryBrowser`
+- Extract shared `useEditorDialogs` hook to editor-core with `WavLoaderStrategy` interface
+- Delete bespoke Roland layout components after migration
 
-2. **Interaction improvements**
-   - Drag-and-drop affordances (drop zones, cursor feedback)
-   - Context menu organization and keyboard shortcuts
-   - Breadcrumb navigation for deep hierarchies
-   - Keyboard navigation (arrow keys, Enter, Escape)
-
-3. **Feedback improvements**
-   - Operation progress with cancel support where possible
-   - Error messages with recovery suggestions
-   - Success confirmations for destructive actions
-   - Undo support for reversible operations
-
-4. **Code refactoring**
-   - Extract reusable components
-   - Simplify state management
-   - Improve component composition
+**UX polish (in shared components, benefiting both editors):**
+- Panel focus indicators
+- Empty state designs with guidance text
+- Loading skeleton placeholders
+- Progress bar indicators for operations
+- Drag-and-drop affordances
+- Keyboard navigation in tree views
+- Context menu improvements
 
 ### Out of Scope
 
 - New library features (new item types, new operations)
+- Vendor-agnostic "Multi" concept (deferred; Sets remain device-specific)
 - Device protocol changes
-- Performance optimization (separate effort if needed)
-- Mobile/responsive layout (desktop-first editor)
+- Performance optimization
+- Mobile/responsive layout
+- Sample rate conversion
+- Automatic sample dependency resolution
 
-## Dependencies and Constraints
+## Dependencies
 
-### Dependencies
-- editor-core shared components (may need enhancements)
-- Existing library-service.ts APIs
-- Plugin architecture for device-specific behavior
+- `editor-core` PluginLibraryBrowser and plugin interfaces (will be modified)
+- Existing Roland plugin architecture (s330-library-plugin, s550-library-plugin)
+- Existing S3K plugin architecture (s3k-library-plugin)
+- `sampler-library` filesystem operations (unchanged)
+- Existing E2E test infrastructure
 
-### Constraints
-- Must maintain backwards compatibility with existing library formats
-- Must not break existing E2E tests
-- Must work with both S-330 and S-550 device configurations
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Migration vs shared hooks only | Migrate Roland to PluginLibraryBrowser | Eliminates divergence at the source; all future UX work lands in one place |
+| UX reference standard | Roland editor | More mature implementation, what PluginLibraryBrowser was based on |
+| Sets modeling | Device-specific CategoryPlugin | Sets are vendor-specific state snapshots; Multi concept deferred |
+| Library browser scope | Show both device-specific and common-area categories | Users need access to both areas |
+| Priority ordering | Alignment first, polish second | UX polish on shared components benefits both editors only after alignment |
 
 ## Open Questions
 
-1. Should we conduct user research to identify specific pain points, or proceed with heuristic evaluation?
-2. Are there specific workflows from the S3K editor UX effort that should inform this work?
-3. What is the priority order for the improvements listed above?
-4. Should keyboard shortcuts be customizable?
-
-## Technical Notes
-
-### Current Architecture
-
-The LibraryPage uses a three-column layout:
-- **Left:** DeviceMemoryPanel (tones/patches on device)
-- **Center:** PluginLibraryTreePanel (library browser with tree navigation)
-- **Right:** ItemPreviewPanel / SampleBundlePreviewPanel (preview with actions)
-
-Key hooks and utilities:
-- `useLibraryConnection` — OPFS/native filesystem connection
-- `useLibraryExport` — Export operations to library
-- `useLibraryImportDialogs` — Import dialog state management
-- `useDirectoryOperations` — Folder CRUD operations
-- Plugin architecture — Device-specific item types and behaviors
-
-### Dialogs (11 total)
-- SaveSetDialog, LoadSetDialog
-- ImportLibraryToneDialog, ImportLibraryPatchDialog, ImportSamplesDialog
-- ExportToneDialog, ExportPatchDialog
-- CreateDirectoryDialog, RenameDirectoryDialog, DeleteDirectoryDialog, MoveItemDialog
-- SampleChopperDialog, LoopEditorDialog, SampleEditorDialog
-
-This dialog complexity suggests potential for consolidation or workflow simplification.
+- [ ] Can Sets be cleanly modeled as a `CategoryPlugin`, or do they need a `headerSections` render slot in PluginLibraryBrowser? (to be determined during Phase 2 prototyping)

--- a/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
@@ -1,271 +1,339 @@
 # Library UX Improvements - Workplan
 
 **Source PRD:** [prd.md](./prd.md)
-**Created:** 2026-03-30
-
----
-
-## GitHub Tracking
-
-| Item | Link |
-|------|------|
-| **Milestone** | TBD |
-| **Parent Issue** | TBD - `[roland-sxx0-editor] Library page UX improvements` |
-| **Labels** | `s330-editor`, `enhancement`, `refactor` |
+**Updated:** 2026-04-07
 
 ---
 
 ## Overview
 
-This workplan addresses UX rough edges in the roland-sxx0-editor Library page through visual polish, interaction improvements, and code refactoring.
+Align both editors on `PluginLibraryBrowser`, then polish the shared components. The Roland editor is the UX reference standard; `PluginLibraryBrowser` must match it before Roland migrates onto it.
 
 ### Current State
-- LibraryPage.tsx: 908 lines (exceeds 500-line guideline)
-- 11 dialogs managed in single component
-- Three-column layout with complex state interactions
-- Plugin architecture for S-330/S-550 device differences
+- **Roland** `LibraryPage.tsx`: 908 lines, bespoke three-column layout, 11+ inline dialogs
+- **S3K** `LibraryPage.tsx`: 596 lines, uses `PluginLibraryBrowser` from editor-core
+- **editor-core** `PluginLibraryBrowser`: shared component that S3K uses but Roland doesn't
 
 ### Target State
-- LibraryPage.tsx: <500 lines via component extraction
-- Clear visual hierarchy and focus management
-- Discoverable interactions with affordances
-- Consistent feedback for all operations
+- Both editors use `PluginLibraryBrowser` from editor-core
+- Roland `LibraryPage.tsx` under 500 lines via hook extraction
+- Shared `useEditorDialogs` hook in editor-core
+- UX polish (empty states, skeletons, keyboard nav, drag-drop affordances) in shared components
 
 ---
 
-## Phase 1: Visual Polish
+## Phase 1: Extract Roland LibraryPage into Hooks
 
-**Goal:** Improve visual hierarchy and feedback without changing functionality.
+**Goal:** Get Roland's `LibraryPage.tsx` under 500 lines via pure refactoring. No rendering changes, no behavior changes.
 
-### Task 1.1: Panel focus indicators
+### Task 1.1: Extract editor dialog management
 
-Add visual indicators showing which panel is currently focused/active.
+Create `modules/roland-sxx0-editor/src/hooks/useRolandEditorDialogs.ts`
+
+Move all dialog state (slice editor, loop editor, chopper, sample editor) and their open/close/save handlers out of LibraryPage. Follow the pattern of S3K's `useEditorDialogs` (`modules/akai-s3k-editor/src/hooks/useEditorDialogs.ts`).
 
 **Files:**
-- `src/pages/LibraryPage.tsx`
-- `src/components/library/DeviceMemoryPanel.tsx`
-- `src/components/library/PluginLibraryTreePanel.tsx`
-- `src/components/library/ItemPreviewPanel.tsx`
+- Create: `modules/roland-sxx0-editor/src/hooks/useRolandEditorDialogs.ts`
+- Modify: `modules/roland-sxx0-editor/src/pages/LibraryPage.tsx`
 
 **Acceptance Criteria:**
-- [ ] Active panel has distinct border/highlight
-- [ ] Focus moves correctly with Tab key
-- [ ] Click on panel focuses it
+- [ ] All dialog state and handlers extracted to hook
+- [ ] LibraryPage imports and calls the hook
+- [ ] No rendering or behavioral changes
+- [ ] Builds cleanly
 
-### Task 1.2: Empty state designs
+### Task 1.2: Extract library data loading
 
-Add meaningful empty states for panels and lists.
+Create `modules/roland-sxx0-editor/src/hooks/useRolandLibraryData.ts`
 
-**Acceptance Criteria:**
-- [ ] Device memory shows helpful message when no banks loaded
-- [ ] Library browser shows guidance when library not connected
-- [ ] Preview panel shows prompt when nothing selected
-- [ ] Empty folders show "No items" with action suggestion
+Move `loadAllLibraryData`, the loading useEffect, refresh handlers, and all tree state (`tonesTree`, `patchesTree`, `drumKitsTree`, `commonSamplesTree`, `sets`, `drumKits`) out of LibraryPage.
 
-### Task 1.3: Loading states and skeletons
-
-Add skeleton loading states for async operations.
+**Files:**
+- Create: `modules/roland-sxx0-editor/src/hooks/useRolandLibraryData.ts`
+- Modify: `modules/roland-sxx0-editor/src/pages/LibraryPage.tsx`
 
 **Acceptance Criteria:**
-- [ ] Library tree shows skeleton while loading
-- [ ] Preview panel shows skeleton while loading item details
-- [ ] Device slots show loading indicator during fetch
+- [ ] All data loading state and effects extracted
+- [ ] Refresh callbacks exposed from hook
+- [ ] No rendering or behavioral changes
 
-### Task 1.4: Operation progress indicators
+### Task 1.3: Extract selection mapping
 
-Improve progress feedback for import/export operations.
+Create `modules/roland-sxx0-editor/src/hooks/useRolandSelectionMapping.ts`
+
+Move `handlePluginSelectionChange` and related selection state. This callback maps editor-core's `ItemSelection` to Roland's page-level `ItemSelection` type and handles side effects (e.g., loading drum kit bundles on selection).
+
+**Files:**
+- Create: `modules/roland-sxx0-editor/src/hooks/useRolandSelectionMapping.ts`
+- Modify: `modules/roland-sxx0-editor/src/pages/LibraryPage.tsx`
 
 **Acceptance Criteria:**
-- [ ] All operations show progress bar with percentage
-- [ ] Long operations show estimated time or step count
-- [ ] Cancel button available where operation is cancellable
-- [ ] Success/failure shown clearly on completion
+- [ ] Selection mapping logic extracted to hook
+- [ ] Side effects (drum kit bundle loading) preserved
+- [ ] No rendering or behavioral changes
+
+### Task 1.4: Extract operation handlers
+
+Move complex operation logic (sample/loop/chopper save callbacks) into existing hooks.
+
+**Files:**
+- Modify: `modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts`
+- Modify: `modules/roland-sxx0-editor/src/hooks/useLibraryImportDialogs.ts`
+- Modify: `modules/roland-sxx0-editor/src/pages/LibraryPage.tsx`
+
+**Acceptance Criteria:**
+- [ ] Save handlers for sample editor, loop editor, chopper extracted
+- [ ] LibraryPage under 500 lines
+- [ ] No rendering or behavioral changes
+
+**Phase 1 Verification:** All existing E2E tests pass (`make test-e2e-roland-library`, `make test-e2e-roland-ui`). No visual changes.
 
 ---
 
-## Phase 2: Interaction Improvements
+## Phase 2: Upstream Roland Patterns to editor-core
 
-**Goal:** Make interactions more discoverable and efficient.
+**Goal:** Make `PluginLibraryBrowser` capable of everything Roland's bespoke layout does. Roland's UX is the standard.
 
-### Task 2.1: Drag-and-drop affordances
+### Task 2.1: Audit Roland vs PluginLibraryBrowser gaps
 
-Add visual cues for drag-and-drop support.
+Read these files side-by-side and document every feature in Roland's bespoke components that `PluginLibraryBrowser` lacks:
 
-**Acceptance Criteria:**
-- [ ] Draggable items show grab cursor on hover
-- [ ] Drop zones highlight when dragging over
-- [ ] Invalid drop targets show "not allowed" indicator
-- [ ] Drag preview shows item being moved
+- `modules/roland-sxx0-editor/src/components/library/PluginLibraryTreePanel.tsx` (Roland's bespoke tree panel)
+- `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx` (shared component)
+- `modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx`
+- `modules/roland-sxx0-editor/src/components/library/ItemPreviewPanel.tsx`
 
-### Task 2.2: Context menu organization
-
-Review and improve context menu structure.
-
-**Acceptance Criteria:**
-- [ ] Related actions grouped logically
-- [ ] Keyboard shortcuts shown next to actions
-- [ ] Destructive actions visually distinct
-- [ ] Most common actions at top
-
-### Task 2.3: Keyboard navigation
-
-Add comprehensive keyboard support.
+**Known gaps:**
+- Context menu rendering and action wiring
+- Sets section with expandable manifests
+- Device memory panel rendering differences
+- `libraryHandle` typed as `FileSystemDirectoryHandle` (S3K casts `StorageDirectoryHandle`)
 
 **Acceptance Criteria:**
-- [ ] Arrow keys navigate within panels
-- [ ] Enter activates/opens selected item
-- [ ] Escape closes dialogs and deselects
-- [ ] Common actions have keyboard shortcuts
-- [ ] Shortcuts documented in help/tooltip
+- [ ] Complete gap list documented
+- [ ] Each gap has a proposed resolution (upstream vs plugin-level vs skip)
 
-### Task 2.4: Breadcrumb navigation
+### Task 2.2: Add context menu support to PluginLibraryBrowser
 
-Add breadcrumbs for deep library hierarchies.
+Roland's `PluginLibraryTreePanel` renders `ContextMenu` internally and converts `PluginContextMenuAction` to `ContextMenuAction` with click handlers. Upstream this pattern into `PluginLibraryBrowser`.
+
+**Files:**
+- Modify: `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx`
 
 **Acceptance Criteria:**
-- [ ] Current path shown as clickable breadcrumbs
-- [ ] Click breadcrumb segment to navigate up
-- [ ] Truncation for very deep paths
-- [ ] Home/root always accessible
+- [ ] PluginLibraryBrowser renders context menus using plugin-provided `getContextMenuActions`
+- [ ] `onContextMenuAction` callback dispatches to consumer
+- [ ] S3K editor gets context menus for free (already defines actions in plugin)
+
+### Task 2.3: Model Sets as a CategoryPlugin
+
+Create a Sets category definition for the Roland plugin. Sets become a `CategoryPlugin` with `categoryId: 'sets'`. Set manifest loading and expansion logic moves from `PluginLibraryTreePanel` into a `useSetsTree` hook that produces `TreeNode[]`.
+
+If Sets don't fit cleanly as a `CategoryPlugin`, fall back to a `headerSections` render slot in `PluginLibraryBrowser`.
+
+**Files:**
+- Create: `modules/roland-sxx0-editor/src/plugins/shared/sets-category.ts`
+- Create: `modules/roland-sxx0-editor/src/hooks/useSetsTree.ts`
+- Modify: `modules/roland-sxx0-editor/src/plugins/s330-library-plugin.tsx`
+- Modify: `modules/roland-sxx0-editor/src/plugins/s550-library-plugin.tsx`
+
+**Acceptance Criteria:**
+- [ ] Sets rendered via CategoryPlugin or headerSections slot
+- [ ] Set expansion/manifest loading preserved
+- [ ] No behavioral regression
+
+### Task 2.4: Widen `libraryHandle` prop type
+
+**Files:**
+- Modify: `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx`
+- Modify: `modules/akai-s3k-editor/src/pages/LibraryPage.tsx` (remove cast)
+
+**Acceptance Criteria:**
+- [ ] Prop accepts `StorageDirectoryHandle`
+- [ ] S3K no longer needs the `as unknown as FileSystemDirectoryHandle` cast
+
+### Task 2.5: Extract shared useEditorDialogs to editor-core
+
+Generalize the pattern from S3K's `useEditorDialogs` and Roland's `useRolandEditorDialogs`. The shared hook accepts a `WavLoaderStrategy` interface:
+
+```typescript
+interface WavLoaderStrategy {
+  loadWav(root, name, nodeType, path?): Promise<WavData>;
+  saveLoopPoints(root, name, nodeType, path?, loopStart, loopEnd): Promise<void>;
+  saveSample(root, name, nodeType, path?, samples, sampleRate): Promise<void>;
+}
+```
+
+Each editor provides a device-specific strategy. The hook manages dialog state identically.
+
+**Files:**
+- Create: `modules/editor-core/src/hooks/useEditorDialogs.ts`
+- Modify: `modules/akai-s3k-editor/src/hooks/useEditorDialogs.ts` (delegate to shared)
+- Modify: `modules/roland-sxx0-editor/src/hooks/useRolandEditorDialogs.ts` (delegate to shared)
+
+**Acceptance Criteria:**
+- [ ] Shared hook in editor-core
+- [ ] Both editors use it with device-specific strategies
+- [ ] No behavioral regression
+
+**Phase 2 Verification:** Build both editors (`make`). All existing E2E tests pass.
 
 ---
 
-## Phase 3: Code Refactoring
+## Phase 3: Migrate Roland to PluginLibraryBrowser
 
-**Goal:** Simplify LibraryPage and improve maintainability.
+**Goal:** Replace Roland's bespoke three-column layout with `PluginLibraryBrowser`. Highest-risk phase.
 
-### Task 3.1: Extract dialog management
+### Task 3.1: Update Roland plugins for complete rendering
 
-Move dialog state and handlers to dedicated hook.
-
-**Files:**
-- Create `src/hooks/useLibraryDialogs.ts`
-- Modify `src/pages/LibraryPage.tsx`
-
-**Acceptance Criteria:**
-- [ ] All dialog state in single hook
-- [ ] Dialog open/close handlers centralized
-- [ ] LibraryPage reduced by ~150 lines
-
-### Task 3.2: Extract panel coordination
-
-Move panel selection and focus state to dedicated hook.
+Ensure plugins provide everything `PluginLibraryBrowser` needs:
+- Device memory panel via `deviceMemory.renderMemoryPanel`
+- Preview panel via `previewPanel.renderPreview`
+- All categories including Sets
+- Context menu actions for all item types
 
 **Files:**
-- Create `src/hooks/useLibraryPanels.ts`
-- Modify `src/pages/LibraryPage.tsx`
+- Modify: `modules/roland-sxx0-editor/src/plugins/s330-library-plugin.tsx`
+- Modify: `modules/roland-sxx0-editor/src/plugins/s550-library-plugin.tsx`
+- Modify: `modules/roland-sxx0-editor/src/plugins/shared/categories.tsx`
 
 **Acceptance Criteria:**
-- [ ] Panel focus state managed in hook
-- [ ] Selection synchronization logic extracted
-- [ ] LibraryPage reduced by ~100 lines
+- [ ] Plugins fully configure PluginLibraryBrowser
+- [ ] All item types have context menu actions
+- [ ] Both s330 and s550 plugins updated
 
-### Task 3.3: Consolidate preview panels
+### Task 3.2: Rewrite LibraryPage to use PluginLibraryBrowser
 
-Unify preview panel rendering logic.
+Replace the bespoke three-column grid with a single `<PluginLibraryBrowser>` call. Model after S3K's `LibraryPage.tsx`.
 
 **Files:**
-- `src/components/library/ItemPreviewPanel.tsx`
-- `src/components/library/SampleBundlePreviewPanel.tsx`
-- `src/components/library/CommonSamplePreviewPanel.tsx`
+- Modify: `modules/roland-sxx0-editor/src/pages/LibraryPage.tsx`
 
 **Acceptance Criteria:**
-- [ ] Single entry point for preview rendering
-- [ ] Type-based dispatch to specialized content
-- [ ] Shared action button patterns
+- [ ] Uses `PluginLibraryBrowser` from editor-core
+- [ ] All categories rendered (tones, patches, drumKits, commonSamples, sets)
+- [ ] Device memory panel works
+- [ ] Preview panel works
+- [ ] All dialogs still work
+- [ ] LibraryPage.tsx is 350-400 lines
 
-### Task 3.4: Extract operation handlers
+### Task 3.3: Delete bespoke components
 
-Move complex operation logic out of LibraryPage.
+**Files to delete:**
+- `modules/roland-sxx0-editor/src/components/library/PluginLibraryTreePanel.tsx` (~579 lines)
+- Any other now-unused bespoke layout components
 
-**Files:**
-- Enhance `src/hooks/useLibraryExport.ts`
-- Enhance `src/hooks/useLibraryImportDialogs.ts`
-- Modify `src/pages/LibraryPage.tsx`
+**Files to keep** (still used by plugin adapters):
+- `DeviceMemoryPanel.tsx` (rendered by plugin's `renderMemoryPanel`)
+- `ItemPreviewPanel.tsx` (rendered by plugin's `renderPreview`)
+- `SampleBundlePreviewPanel.tsx`, `CommonSamplePreviewPanel.tsx` (sub-panels)
+- All dialog components
 
-**Acceptance Criteria:**
-- [ ] Sample editor save logic extracted
-- [ ] Loop editor save logic extracted
-- [ ] Chopper save logic extracted
-- [ ] LibraryPage reduced by ~150 lines
+### Task 3.4: Preserve test selectors
+
+Add `data-testid` attributes to `PluginLibraryBrowser` and `TreeSection` in editor-core to match existing Roland E2E test selectors.
+
+**E2E test files to verify:**
+- `modules/roland-sxx0-editor/e2e/library-sets.spec.ts`
+- `modules/roland-sxx0-editor/e2e/library-directories.spec.ts`
+- `modules/roland-sxx0-editor/e2e/library-opfs.spec.ts`
+- `modules/roland-sxx0-editor/e2e/library-chopper-save.spec.ts`
+
+**Phase 3 Verification:** All Roland E2E tests pass. All S3K E2E tests pass. Visual regression check on both editors.
 
 ---
 
-## Phase 4: Testing and Documentation
+## Phase 4: UX Polish on Shared Components
 
-**Goal:** Ensure quality and document changes.
+**Goal:** Improve UX in editor-core so both editors benefit simultaneously.
 
-### Task 4.1: Update E2E tests
+### Task 4.1: Empty states
 
-Verify and update E2E tests for changed interactions.
+- `PluginLibraryBrowser`: styled empty state with icon and connect prompt
+- `TreeSection`: empty category message with icon and action hint
 
-**Acceptance Criteria:**
-- [ ] All existing library E2E tests pass
-- [ ] New keyboard navigation tested
-- [ ] Focus management tested
-- [ ] No regression in test coverage
+**Files:**
+- Modify: `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx`
+- Modify: `modules/editor-core/src/components/library/TreeSection.tsx`
 
-### Task 4.2: Add component tests
+### Task 4.2: Loading skeletons
 
-Add unit tests for extracted hooks and components.
+Replace "Loading library..." text with animated skeleton placeholders matching tree section layout.
 
-**Acceptance Criteria:**
-- [ ] useLibraryDialogs hook tested
-- [ ] useLibraryPanels hook tested
-- [ ] Focus management logic tested
+**Files:**
+- Modify: `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx`
+- Create: `modules/editor-core/src/components/library/TreeSkeleton.tsx` (if needed)
 
-### Task 4.3: Update documentation
+### Task 4.3: Progress indicators
 
-Document new keyboard shortcuts and interactions.
+Progress bar component for import/export operations. Inline progress in preview panel during active transfers.
 
-**Acceptance Criteria:**
-- [ ] Keyboard shortcuts listed in app help
-- [ ] README updated with UX changes
-- [ ] CHANGELOG entry added
+**Files:**
+- Modify: `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx`
+
+### Task 4.4: Drag-drop affordances
+
+- Grab cursor on draggable items
+- Drop zone highlight during drag
+- Invalid drop target indicator
+- Drag preview showing item name/icon
+
+**Files:**
+- Modify: `modules/editor-core/src/components/library/TreeView.tsx`
+- Modify: `modules/editor-core/src/components/library/TreeSection.tsx`
+- Modify: `modules/editor-core/src/design/library.css`
+
+### Task 4.5: Keyboard navigation
+
+- Arrow keys: up/down to move selection, left/right to collapse/expand
+- Enter to select/activate
+- Delete to delete with confirmation
+- Escape to deselect/close
+
+**Files:**
+- Modify: `modules/editor-core/src/components/library/TreeView.tsx`
+
+**Phase 4 Verification:** Manual testing on both editors. All E2E tests pass.
 
 ---
 
-## Dependencies
+## Dependency Graph
 
-| Task | Depends On |
+```
+Phase 1 (pure Roland refactor, no deps)
+  1.1 -> 1.2 -> 1.3 -> 1.4
+
+Phase 2 (editor-core changes, depends on Phase 1)
+  2.1 (audit) -> 2.2, 2.3, 2.4, 2.5 (can parallelize after audit)
+
+Phase 3 (depends on Phase 1 + Phase 2)
+  3.1 -> 3.2 -> 3.3 + 3.4
+
+Phase 4 (depends on Phase 3, tasks independent)
+  4.1, 4.2, 4.3, 4.4, 4.5 (parallel)
+```
+
+---
+
+## Risk Mitigation
+
+| Risk | Mitigation |
 |------|------------|
-| Phase 2 | Phase 1 (visual indicators needed for interaction feedback) |
-| Phase 3 | Phase 1-2 (refactoring after behavior is finalized) |
-| Phase 4 | Phase 1-3 |
+| E2E breakage during migration (Phase 3) | Run `make test-e2e-roland` after each step. Add `data-testid` attrs early. |
+| Sets don't fit as CategoryPlugin | Prototype first; fall back to `headerSections` render slot if needed. |
+| Selection type divergence | Roland page-level `ItemSelection` may persist for dialog callbacks; mapping hook bridges it to editor-core's type. |
+| Two Roland plugins (s330/s550) | Both implement same `DeviceLibraryPlugin` interface. Test with both device configs. |
 
 ---
 
-## Success Criteria
+## Critical Files
 
-### Phase 1 Complete When:
-- [ ] All panels have clear focus indicators
-- [ ] Empty states guide user actions
-- [ ] Loading states prevent confusion
-- [ ] Operation progress is always visible
-
-### Phase 2 Complete When:
-- [ ] Drag-and-drop is visually discoverable
-- [ ] Keyboard users can complete all workflows
-- [ ] Deep navigation is efficient
-
-### Phase 3 Complete When:
-- [ ] LibraryPage.tsx is <500 lines
-- [ ] No functional regression
-- [ ] Code is more maintainable
-
-### Phase 4 Complete When:
-- [ ] All E2E tests pass
-- [ ] New functionality tested
-- [ ] Changes documented
-
----
-
-## Estimated Scope
-
-| Phase | Tasks | Effort |
-|-------|-------|--------|
-| Phase 1 | 4 tasks | 2-3 days |
-| Phase 2 | 4 tasks | 3-4 days |
-| Phase 3 | 4 tasks | 2-3 days |
-| Phase 4 | 3 tasks | 1-2 days |
-| **Total** | **15 tasks** | **~2 milestones** |
+| File | Role |
+|------|------|
+| `modules/roland-sxx0-editor/src/pages/LibraryPage.tsx` | 908-line file to decompose and migrate |
+| `modules/editor-core/src/components/library/PluginLibraryBrowser.tsx` | Shared component to match Roland UX |
+| `modules/editor-core/src/components/library/plugins/types.ts` | Plugin interface definitions |
+| `modules/roland-sxx0-editor/src/components/library/PluginLibraryTreePanel.tsx` | Bespoke component to be replaced |
+| `modules/roland-sxx0-editor/src/plugins/shared/categories.tsx` | Category definitions to extend with Sets |
+| `modules/akai-s3k-editor/src/hooks/useEditorDialogs.ts` | Pattern to generalize into editor-core |
+| `modules/akai-s3k-editor/src/pages/LibraryPage.tsx` | Reference for PluginLibraryBrowser usage |

--- a/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
@@ -1,0 +1,271 @@
+# Library UX Improvements - Workplan
+
+**Source PRD:** [prd.md](./prd.md)
+**Created:** 2026-03-30
+
+---
+
+## GitHub Tracking
+
+| Item | Link |
+|------|------|
+| **Milestone** | TBD |
+| **Parent Issue** | TBD - `[roland-sxx0-editor] Library page UX improvements` |
+| **Labels** | `s330-editor`, `enhancement`, `refactor` |
+
+---
+
+## Overview
+
+This workplan addresses UX rough edges in the roland-sxx0-editor Library page through visual polish, interaction improvements, and code refactoring.
+
+### Current State
+- LibraryPage.tsx: 908 lines (exceeds 500-line guideline)
+- 11 dialogs managed in single component
+- Three-column layout with complex state interactions
+- Plugin architecture for S-330/S-550 device differences
+
+### Target State
+- LibraryPage.tsx: <500 lines via component extraction
+- Clear visual hierarchy and focus management
+- Discoverable interactions with affordances
+- Consistent feedback for all operations
+
+---
+
+## Phase 1: Visual Polish
+
+**Goal:** Improve visual hierarchy and feedback without changing functionality.
+
+### Task 1.1: Panel focus indicators
+
+Add visual indicators showing which panel is currently focused/active.
+
+**Files:**
+- `src/pages/LibraryPage.tsx`
+- `src/components/library/DeviceMemoryPanel.tsx`
+- `src/components/library/PluginLibraryTreePanel.tsx`
+- `src/components/library/ItemPreviewPanel.tsx`
+
+**Acceptance Criteria:**
+- [ ] Active panel has distinct border/highlight
+- [ ] Focus moves correctly with Tab key
+- [ ] Click on panel focuses it
+
+### Task 1.2: Empty state designs
+
+Add meaningful empty states for panels and lists.
+
+**Acceptance Criteria:**
+- [ ] Device memory shows helpful message when no banks loaded
+- [ ] Library browser shows guidance when library not connected
+- [ ] Preview panel shows prompt when nothing selected
+- [ ] Empty folders show "No items" with action suggestion
+
+### Task 1.3: Loading states and skeletons
+
+Add skeleton loading states for async operations.
+
+**Acceptance Criteria:**
+- [ ] Library tree shows skeleton while loading
+- [ ] Preview panel shows skeleton while loading item details
+- [ ] Device slots show loading indicator during fetch
+
+### Task 1.4: Operation progress indicators
+
+Improve progress feedback for import/export operations.
+
+**Acceptance Criteria:**
+- [ ] All operations show progress bar with percentage
+- [ ] Long operations show estimated time or step count
+- [ ] Cancel button available where operation is cancellable
+- [ ] Success/failure shown clearly on completion
+
+---
+
+## Phase 2: Interaction Improvements
+
+**Goal:** Make interactions more discoverable and efficient.
+
+### Task 2.1: Drag-and-drop affordances
+
+Add visual cues for drag-and-drop support.
+
+**Acceptance Criteria:**
+- [ ] Draggable items show grab cursor on hover
+- [ ] Drop zones highlight when dragging over
+- [ ] Invalid drop targets show "not allowed" indicator
+- [ ] Drag preview shows item being moved
+
+### Task 2.2: Context menu organization
+
+Review and improve context menu structure.
+
+**Acceptance Criteria:**
+- [ ] Related actions grouped logically
+- [ ] Keyboard shortcuts shown next to actions
+- [ ] Destructive actions visually distinct
+- [ ] Most common actions at top
+
+### Task 2.3: Keyboard navigation
+
+Add comprehensive keyboard support.
+
+**Acceptance Criteria:**
+- [ ] Arrow keys navigate within panels
+- [ ] Enter activates/opens selected item
+- [ ] Escape closes dialogs and deselects
+- [ ] Common actions have keyboard shortcuts
+- [ ] Shortcuts documented in help/tooltip
+
+### Task 2.4: Breadcrumb navigation
+
+Add breadcrumbs for deep library hierarchies.
+
+**Acceptance Criteria:**
+- [ ] Current path shown as clickable breadcrumbs
+- [ ] Click breadcrumb segment to navigate up
+- [ ] Truncation for very deep paths
+- [ ] Home/root always accessible
+
+---
+
+## Phase 3: Code Refactoring
+
+**Goal:** Simplify LibraryPage and improve maintainability.
+
+### Task 3.1: Extract dialog management
+
+Move dialog state and handlers to dedicated hook.
+
+**Files:**
+- Create `src/hooks/useLibraryDialogs.ts`
+- Modify `src/pages/LibraryPage.tsx`
+
+**Acceptance Criteria:**
+- [ ] All dialog state in single hook
+- [ ] Dialog open/close handlers centralized
+- [ ] LibraryPage reduced by ~150 lines
+
+### Task 3.2: Extract panel coordination
+
+Move panel selection and focus state to dedicated hook.
+
+**Files:**
+- Create `src/hooks/useLibraryPanels.ts`
+- Modify `src/pages/LibraryPage.tsx`
+
+**Acceptance Criteria:**
+- [ ] Panel focus state managed in hook
+- [ ] Selection synchronization logic extracted
+- [ ] LibraryPage reduced by ~100 lines
+
+### Task 3.3: Consolidate preview panels
+
+Unify preview panel rendering logic.
+
+**Files:**
+- `src/components/library/ItemPreviewPanel.tsx`
+- `src/components/library/SampleBundlePreviewPanel.tsx`
+- `src/components/library/CommonSamplePreviewPanel.tsx`
+
+**Acceptance Criteria:**
+- [ ] Single entry point for preview rendering
+- [ ] Type-based dispatch to specialized content
+- [ ] Shared action button patterns
+
+### Task 3.4: Extract operation handlers
+
+Move complex operation logic out of LibraryPage.
+
+**Files:**
+- Enhance `src/hooks/useLibraryExport.ts`
+- Enhance `src/hooks/useLibraryImportDialogs.ts`
+- Modify `src/pages/LibraryPage.tsx`
+
+**Acceptance Criteria:**
+- [ ] Sample editor save logic extracted
+- [ ] Loop editor save logic extracted
+- [ ] Chopper save logic extracted
+- [ ] LibraryPage reduced by ~150 lines
+
+---
+
+## Phase 4: Testing and Documentation
+
+**Goal:** Ensure quality and document changes.
+
+### Task 4.1: Update E2E tests
+
+Verify and update E2E tests for changed interactions.
+
+**Acceptance Criteria:**
+- [ ] All existing library E2E tests pass
+- [ ] New keyboard navigation tested
+- [ ] Focus management tested
+- [ ] No regression in test coverage
+
+### Task 4.2: Add component tests
+
+Add unit tests for extracted hooks and components.
+
+**Acceptance Criteria:**
+- [ ] useLibraryDialogs hook tested
+- [ ] useLibraryPanels hook tested
+- [ ] Focus management logic tested
+
+### Task 4.3: Update documentation
+
+Document new keyboard shortcuts and interactions.
+
+**Acceptance Criteria:**
+- [ ] Keyboard shortcuts listed in app help
+- [ ] README updated with UX changes
+- [ ] CHANGELOG entry added
+
+---
+
+## Dependencies
+
+| Task | Depends On |
+|------|------------|
+| Phase 2 | Phase 1 (visual indicators needed for interaction feedback) |
+| Phase 3 | Phase 1-2 (refactoring after behavior is finalized) |
+| Phase 4 | Phase 1-3 |
+
+---
+
+## Success Criteria
+
+### Phase 1 Complete When:
+- [ ] All panels have clear focus indicators
+- [ ] Empty states guide user actions
+- [ ] Loading states prevent confusion
+- [ ] Operation progress is always visible
+
+### Phase 2 Complete When:
+- [ ] Drag-and-drop is visually discoverable
+- [ ] Keyboard users can complete all workflows
+- [ ] Deep navigation is efficient
+
+### Phase 3 Complete When:
+- [ ] LibraryPage.tsx is <500 lines
+- [ ] No functional regression
+- [ ] Code is more maintainable
+
+### Phase 4 Complete When:
+- [ ] All E2E tests pass
+- [ ] New functionality tested
+- [ ] Changes documented
+
+---
+
+## Estimated Scope
+
+| Phase | Tasks | Effort |
+|-------|-------|--------|
+| Phase 1 | 4 tasks | 2-3 days |
+| Phase 2 | 4 tasks | 3-4 days |
+| Phase 3 | 4 tasks | 2-3 days |
+| Phase 4 | 3 tasks | 1-2 days |
+| **Total** | **15 tasks** | **~2 milestones** |

--- a/docs/1.0/s3k-library-page/README.md
+++ b/docs/1.0/s3k-library-page/README.md
@@ -1,7 +1,9 @@
 # S3000XL Library Page Conformance
 
-**Status:** Planning
+**Status:** Superseded
 **Feature Branch:** `feature/s3k-library-page`
+
+> **Note:** This feature effort has been superseded by the [Library UX Improvements](../001-IN-PROGRESS/library-ux/) initiative, which covers both the Roland S-330/S-550 and Akai S3000XL editors with a unified alignment and polish strategy. The S3K library page already has a three-column layout, plugin architecture, and transfer dialogs implemented. Remaining work (UX polish, shared code extraction, editor parity) is tracked under the library-ux effort.
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Rewrite library-ux PRD and workplan to cover both Roland S-330/S-550 and Akai S3000XL editors with a unified alignment strategy
- Core plan: migrate Roland onto shared `PluginLibraryBrowser` (updating it to match Roland's UX standard), extract shared hooks to editor-core, then polish shared components
- Mark s3k-library-page feature docs as superseded by this effort

## Test plan

- [ ] Documentation review — no code changes