### PR TITLE
docs: session journal, SCSI travel log, feature status updates

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -259,6 +259,24 @@ Byte-based progress is the only meaningful primary measure.
 
 **Consistency:** All progress indicators across the application must use the same layout, formatting, and fields. Define a shared progress component or type rather than ad-hoc progress UI per dialog.
 
+## Development Journal
+
+At least once per session, write a journal entry in `DEVELOPMENT-NOTES.md` (project root). Each entry must include:
+
+1. **Date and session summary** — what was the goal of the session
+2. **What we tried** — approaches attempted, experiments run
+3. **What we accomplished** — concrete outcomes, commits, features shipped
+4. **What worked well** — successful strategies, good instincts
+5. **What didn't work** — blind alleys, incorrect assumptions, wasted effort
+6. **Course corrections** — how the user asked you to do things differently than you initially tried. This is the most important part. Document the specific feedback, what you were doing wrong, and what the user wanted instead.
+
+The journal serves as:
+- A record of how the audiocontrol project is built
+- A source of insight into patterns of what works and what doesn't
+- A basis for continuous improvement in how we interact, the assumptions agents make, and user preferences
+
+Write entries in chronological order. Be honest about mistakes — the value is in the pattern recognition, not in looking good. Use the same frank, specific tone as `SCSI-NOTES.md`.
+
 ## Critical Don'ts
 
 - Never implement fallbacks or mock data outside test code

--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -1,0 +1,75 @@
+# Development Notes
+
+Session journal for the audiocontrol project. Documents what we tried, what worked, what didn't, and — most importantly — how the user course-corrected the agent's approach.
+
+---
+
+## 2026-04-09 / 2026-04-10: Library UX, Disk Browser, SDS Speed
+
+### Session goal
+Improve the S3000XL editor's library UX: disk browser, drag-and-drop, sample transfer speed.
+
+### What we accomplished
+- SCSI disk browser with lazy metadata loading, collapsible volumes, context menus
+- Drag-and-drop between disk browser, library, and device memory
+- Three-section library (Samples, Programs, Akai Programs) with expandable programs
+- NavLink query param preservation (real app bug, not just test issue)
+- SDS upload 9x faster via packet batching (227ms/packet → 25ms/packet)
+- Bridge hardening: disconnect cancellation, exponential backoff, dynamic timeouts
+- ASPACK discovery: 23.4 KB/s proprietary transfer (10x faster than batched SDS)
+- Protocol documentation, SCSI travel log, exploration plan for ASPACK
+
+### What worked well
+- **Node.js test scripts for hardware experiments.** Writing 50-line tsx scripts to probe SCSI behavior was dramatically faster than debugging through the web app. The batch SDS and ASPACK throughput measurements would have been impossible without this approach.
+- **Reading the MESA II analysis.** The CDB flag byte discovery came directly from the mesa-plug-harness SCSI-PROTOCOL.md document. Prior art matters.
+- **Incremental deployment.** `make deploy-scsi-bridge` → test → iterate. Short feedback loops on real hardware.
+
+### What didn't work
+- **Streaming port 6870.** Spent time investigating, writing a test, connecting — it doesn't relay device ACKs. Dead end.
+- **Guessing at fixes without data.** Added sleeps, blamed stale data, assumed TCP overhead — all wrong. The timing instrumentation (`send_ms`/`recv_ms`) was the only thing that revealed the truth.
+- **Pre-loading all files for save.** Tried to load all 27 samples in a volume before opening the save dialog. Hung the UI for minutes. Should have loaded on demand.
+
+### Course corrections (user feedback)
+
+**"STOP TRYING TO ADD DELAYS"**
+I kept adding defensive sleeps between SCSI operations — 50ms here, 100ms there, 3-second "commit" waits. The user had to say this multiple times before I internalized it. The device ACK is definitive. If it ACKs, it's ready. Sleeps are never the first answer.
+
+**"Why are you using pixel values instead of the 12-column layout system?"**
+I hardcoded pixel widths (`w-72`, `width: 230px`) for layout columns. The user pointed out this is bad for responsive design. Switched to proportional flex ratios (2:2:3:2). Also: the user noted my pixel changes didn't visibly take effect because of caching — I should have verified the change was visible.
+
+**"Why didn't you interrogate the actual sample file?"**
+When encountering `sampleRate: 0` in WAV files, I fell back to a hardcoded `44100` default. The user correctly asked why I'd guess instead of reading the actual data. The WAV was written with rate 0 (pre-fix bug), so the error should surface to the user, not be silently papered over.
+
+**"Double-click on list items is super not standard"**
+I added double-click-to-download on disk browser items. The user pointed out this is non-standard UX. Also, "Download as WAV" was wrong for a library context — the primary action should be "Save to Library" via context menu.
+
+**"The download seems stuck" / "No progress indicator"**
+Multiple times I implemented operations with no loading indicators. The disk browser scan, disk data loading, and sample transfers all launched with no visible feedback. The user had to ask for progress indicators repeatedly before I started treating them as a first-class requirement.
+
+**"Why does it take so long to start showing disk contents?"**
+I was reading the entire first partition (60MB+) before displaying anything. The user's question prompted lazy metadata loading — read only FAT + volume directory (~50KB), load file data on demand.
+
+**"Don't blame the device / Don't make things up"**
+I said the S3000XL needed time to recover after a failed transfer. I said MESA II used direct SCSI block writes to sampler memory. Both were fabrications. The user called me out each time. The rule: every claim needs hardware evidence or documentation.
+
+**"Why don't you just try a larger packet and see if it works?"**
+I was theorizing about whether the S3000XL could accept larger SDS packets or ASPACK chunks. Instead of reasoning about it, the user said to just try it. The experiments took seconds and answered the question definitively.
+
+**"The current sysex channel is meant for the control plane, not the data plane"**
+I tested ASPACK throughput via the bridge's HTTP `/sds/send` endpoint (control plane) and got 0.6 KB/s. The user pointed out this was the wrong path — data transfer needs to go through raw SCSI CDBs with MIDI mode kept enabled. On the data plane, ASPACK achieved 23.4 KB/s.
+
+**"File an issue" / "Document your findings" / "Write it to the feature documentation"**
+The user consistently asked me to persist findings in the right places — issues for future work, docs for protocol knowledge, plan files for exploration strategies. My instinct was to keep moving; the user's instinct was to document first.
+
+**"Can you also make sure you add dates?"**
+I wrote the SCSI travel log without specific timestamps. The user wanted a timeline for future reference and blog writing. Added timestamps reconstructed from git history.
+
+### Patterns observed
+
+1. **I default to complexity.** The user repeatedly pushed for simpler approaches — try it before theorizing, use raw CDBs before building abstractions, test from Node before touching React.
+
+2. **I underinvest in UX feedback.** Loading spinners, progress bars, error messages — I treat these as afterthoughts. The user treats them as requirements equal to the feature itself.
+
+3. **I make things up when I don't know.** When uncertain, I generate plausible-sounding explanations instead of saying "I don't know, let me check." The user catches this every time.
+
+4. **I don't document proactively.** Left to my own devices, I'd keep coding. The user consistently asks for documentation, issues, plans. The documentation produced in this session (protocol reference, travel log, exploration plan) is arguably more valuable than the code.

--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -2,74 +2,74 @@
 
 Session journal for the audiocontrol project. Documents what we tried, what worked, what didn't, and — most importantly — how the user course-corrected the agent's approach.
 
+Each correction is tagged by category for pattern analysis:
+- **[COMPLEXITY]** — agent defaulted to complex solution, user wanted simpler
+- **[UX]** — agent neglected user-facing feedback
+- **[FABRICATION]** — agent stated something without evidence
+- **[DOCUMENTATION]** — agent didn't document or read existing docs
+- **[PROCESS]** — agent didn't follow established workflow
+
 ---
 
 ## 2026-04-09 / 2026-04-10: Library UX, Disk Browser, SDS Speed
 
-### Session goal
-Improve the S3000XL editor's library UX: disk browser, drag-and-drop, sample transfer speed.
+### Feature: library-ux
+### Worktree: audiocontrol-library-ux
 
-### What we accomplished
-- SCSI disk browser with lazy metadata loading, collapsible volumes, context menus
-- Drag-and-drop between disk browser, library, and device memory
-- Three-section library (Samples, Programs, Akai Programs) with expandable programs
-- NavLink query param preservation (real app bug, not just test issue)
-- SDS upload 9x faster via packet batching (227ms/packet → 25ms/packet)
-- Bridge hardening: disconnect cancellation, exponential backoff, dynamic timeouts
-- ASPACK discovery: 23.4 KB/s proprietary transfer (10x faster than batched SDS)
-- Protocol documentation, SCSI travel log, exploration plan for ASPACK
+### Goal
+Improve the S3000XL editor's library UX: SCSI disk browser, drag-and-drop workflows, sample transfer speed.
 
-### What worked well
-- **Node.js test scripts for hardware experiments.** Writing 50-line tsx scripts to probe SCSI behavior was dramatically faster than debugging through the web app. The batch SDS and ASPACK throughput measurements would have been impossible without this approach.
-- **Reading the MESA II analysis.** The CDB flag byte discovery came directly from the mesa-plug-harness SCSI-PROTOCOL.md document. Prior art matters.
-- **Incremental deployment.** `make deploy-scsi-bridge` → test → iterate. Short feedback loops on real hardware.
+### Accomplished
+- SCSI disk browser with lazy metadata loading (~50KB vs 60MB+), collapsible volumes, context menus (`689da1fd`)
+- Drag-and-drop: disk→library, disk→device, library→device with type filtering (`b98ccdf0`, `bfe221b6`, `6e0e1fae`)
+- Three library sections (Samples, Programs, Akai Programs) with expandable programs (`112e457c`)
+- NavLink query param preservation — real app bug fix (`0d2ef0bf`)
+- SDS upload 9x faster via packet batching, 227ms→25ms per packet (`7088d535`)
+- Bridge hardening: disconnect cancellation, exponential backoff, dynamic timeouts (`16a8b36c`, `2485d76e`)
+- ASPACK discovery: 23.4 KB/s proprietary transfer, 10.6x faster than batched SDS (`e314fbc5`)
+- S3000XL SysEx protocol reference doc (`e314fbc5`)
+- SCSI travel log covering full reverse engineering journey (`0f308de8`, `b7d61f95`, `793164e6`)
+- Progress indicators meeting project spec (bytes, elapsed, ETA) (`5bc223a3`)
+- Sample rename after SDS upload (`510a2ace`)
+- PR #186 merged to main
 
-### What didn't work
-- **Streaming port 6870.** Spent time investigating, writing a test, connecting — it doesn't relay device ACKs. Dead end.
-- **Guessing at fixes without data.** Added sleeps, blamed stale data, assumed TCP overhead — all wrong. The timing instrumentation (`send_ms`/`recv_ms`) was the only thing that revealed the truth.
-- **Pre-loading all files for save.** Tried to load all 27 samples in a volume before opening the save dialog. Hung the UI for minutes. Should have loaded on demand.
+### Didn't Work
+- Streaming port 6870 for SDS — doesn't relay device ACKs, dead end
+- ASPACK multi-chunk writes (offset > 0) — empty reply, unsolved
+- ASPACK sample creation — can only overwrite existing, not create new
+- Pre-loading all volume files before save — hung UI for minutes
+- Multiple iterations of defensive sleeps — all removed
 
-### Course corrections (user feedback)
+### Course Corrections
+- **[COMPLEXITY]** Added defensive sleeps (50ms, 100ms, 3s) throughout SDS path. User: "STOP TRYING TO ADD DELAYS." ACK is definitive. Removed all sleeps, implemented exponential backoff.
+- **[COMPLEXITY]** Pre-loaded all 27 files in a volume before opening save dialog. User saw it hang. Fixed to load single file on demand.
+- **[COMPLEXITY]** Built EditorDialogGroup package to share dialog rendering. Circular dependency. Abandoned after user asked "what are you doing?"
+- **[UX]** Implemented disk browser with no loading indicators. User: "Garbage UX." Added scanning/reading states.
+- **[UX]** No progress indicator on sample transfers. User had to ask repeatedly. Now required by project guidelines.
+- **[UX]** Progress showed item count (3/10 samples) not bytes. User: "Showing the number of samples is useless since samples can range in size."
+- **[UX]** Double-click to download — user: "double-clicking on an item almost never means download" and "Download as WAV is very counterintuitive in the context of a library."
+- **[UX]** Hardcoded pixel widths for layout. User: "why are you using pixel values instead of the 12-column layout system?"
+- **[FABRICATION]** Said S3000XL needed time to recover after failed transfer. User: "don't blame the device."
+- **[FABRICATION]** Said MESA II used direct SCSI block writes to sampler memory. User: "No you can't write directly to the sampler's memory. You just made that up."
+- **[FABRICATION]** Guessed sampler was stuck from previous test without checking logs. User: "why do you think that?"
+- **[FABRICATION]** Fell back to hardcoded 44100 for zero sample rate. User: "why would you fall back to 44100 instead of interrogating the actual sample file?"
+- **[DOCUMENTATION]** Didn't read the library-ux feature docs (PRD, workplan) at session start. Operated blind to 14 sub-feature documents and existing phase structure for the entire session.
+- **[DOCUMENTATION]** User had to ask for protocol documentation, SCSI travel log, progress indicator guidelines — agent didn't create them proactively.
+- **[PROCESS]** Didn't create feature branch/worktree for continuous improvement — started work on library-ux branch. User: "What do our project guidelines say about feature branches and worktrees?"
+- **[PROCESS]** Set 5-minute timeout on a test expected to take seconds. User: "why did you set a 5 minute timeout?"
+- **[PROCESS]** Used `sleep 30` to wait for test results instead of checking immediately. User: "why did you wait for 2 minutes to find out it was stuck?"
+- **[PROCESS]** Tested ASPACK via control plane (HTTP sds/send) instead of data plane (raw SCSI CDBs). User: "the current sysex channel is meant for the control plane, not the data plane."
 
-**"STOP TRYING TO ADD DELAYS"**
-I kept adding defensive sleeps between SCSI operations — 50ms here, 100ms there, 3-second "commit" waits. The user had to say this multiple times before I internalized it. The device ACK is definitive. If it ACKs, it's ready. Sleeps are never the first answer.
+### Quantitative
+- User messages: ~350+
+- Commits: 37 (on library-ux branch)
+- User corrections: ~20
+- Tool calls: thousands (extended session spanning two days)
+- Time sinks: SDS speed investigation (~4 hours), ASPACK exploration (~2 hours), drag-drop type filtering (~1 hour)
 
-**"Why are you using pixel values instead of the 12-column layout system?"**
-I hardcoded pixel widths (`w-72`, `width: 230px`) for layout columns. The user pointed out this is bad for responsive design. Switched to proportional flex ratios (2:2:3:2). Also: the user noted my pixel changes didn't visibly take effect because of caching — I should have verified the change was visible.
-
-**"Why didn't you interrogate the actual sample file?"**
-When encountering `sampleRate: 0` in WAV files, I fell back to a hardcoded `44100` default. The user correctly asked why I'd guess instead of reading the actual data. The WAV was written with rate 0 (pre-fix bug), so the error should surface to the user, not be silently papered over.
-
-**"Double-click on list items is super not standard"**
-I added double-click-to-download on disk browser items. The user pointed out this is non-standard UX. Also, "Download as WAV" was wrong for a library context — the primary action should be "Save to Library" via context menu.
-
-**"The download seems stuck" / "No progress indicator"**
-Multiple times I implemented operations with no loading indicators. The disk browser scan, disk data loading, and sample transfers all launched with no visible feedback. The user had to ask for progress indicators repeatedly before I started treating them as a first-class requirement.
-
-**"Why does it take so long to start showing disk contents?"**
-I was reading the entire first partition (60MB+) before displaying anything. The user's question prompted lazy metadata loading — read only FAT + volume directory (~50KB), load file data on demand.
-
-**"Don't blame the device / Don't make things up"**
-I said the S3000XL needed time to recover after a failed transfer. I said MESA II used direct SCSI block writes to sampler memory. Both were fabrications. The user called me out each time. The rule: every claim needs hardware evidence or documentation.
-
-**"Why don't you just try a larger packet and see if it works?"**
-I was theorizing about whether the S3000XL could accept larger SDS packets or ASPACK chunks. Instead of reasoning about it, the user said to just try it. The experiments took seconds and answered the question definitively.
-
-**"The current sysex channel is meant for the control plane, not the data plane"**
-I tested ASPACK throughput via the bridge's HTTP `/sds/send` endpoint (control plane) and got 0.6 KB/s. The user pointed out this was the wrong path — data transfer needs to go through raw SCSI CDBs with MIDI mode kept enabled. On the data plane, ASPACK achieved 23.4 KB/s.
-
-**"File an issue" / "Document your findings" / "Write it to the feature documentation"**
-The user consistently asked me to persist findings in the right places — issues for future work, docs for protocol knowledge, plan files for exploration strategies. My instinct was to keep moving; the user's instinct was to document first.
-
-**"Can you also make sure you add dates?"**
-I wrote the SCSI travel log without specific timestamps. The user wanted a timeline for future reference and blog writing. Added timestamps reconstructed from git history.
-
-### Patterns observed
-
-1. **I default to complexity.** The user repeatedly pushed for simpler approaches — try it before theorizing, use raw CDBs before building abstractions, test from Node before touching React.
-
-2. **I underinvest in UX feedback.** Loading spinners, progress bars, error messages — I treat these as afterthoughts. The user treats them as requirements equal to the feature itself.
-
-3. **I make things up when I don't know.** When uncertain, I generate plausible-sounding explanations instead of saying "I don't know, let me check." The user catches this every time.
-
-4. **I don't document proactively.** Left to my own devices, I'd keep coding. The user consistently asks for documentation, issues, plans. The documentation produced in this session (protocol reference, travel log, exploration plan) is arguably more valuable than the code.
+### Insights
+1. Agent should read feature workplan at session start — would have known about existing phases
+2. Every hardware claim should be tested, not reasoned about
+3. Progress indicators should be implemented at the same time as the feature, not retrofitted
+4. Documentation (protocol ref, travel log) was ultimately more valuable than some of the code
+5. The user's instinct to "just try it" was right every time — the ASPACK discovery, the batch SDS test, the larger packet size test all happened because the user pushed past theorizing

--- a/SCSI-NOTES.md
+++ b/SCSI-NOTES.md
@@ -149,19 +149,50 @@ SheepShaver SCSI bridge works for disk access but MESA II's SCSI Plug traffic co
 
 ## 2026-04-05 23:24 PDT: s2p Streaming MIDI Server
 
-### Strategy
-Add a persistent TCP streaming server to s2p (port 6870) for low-latency MIDI communication, bypassing the per-command protobuf overhead.
+### Motivation
+The protobuf API (port 6868) creates a new TCP connection per SCSI command. Each SysEx request/response requires multiple SCSI commands (enable MIDI → send → poll → read → disable MIDI), each as a separate TCP connection. Hypothesis: a persistent connection with internal SCSI polling could eliminate network round trips.
 
-### What we built
-- MSG_INIT/MSG_SEND/MSG_DATA/MSG_ERROR frame protocol
-- Persistent TCP connection with TCP_NODELAY
-- MSG_SAMPLE_READ for SDS sample download (sends Dump Request, handles ACK loop internally)
+### What we built in s2p (C++)
+- `midi_streaming_server.cpp` — TCP server on port 6870
+- Frame protocol: `[4-byte LE length][1-byte type][payload]`
+- MSG_INIT (0x01): set target SCSI ID, establish session
+- MSG_SEND (0x02): send SysEx, server polls SCSI bus internally at 500µs intervals, pushes response
+- MSG_DATA (0x03): server pushes response/unsolicited data
+- MSG_ERROR (0x04): server pushes error
+- MSG_SAMPLE_READ (0x05): send SDS Dump Request, handle ACK loop internally
 
-### Outcome
-The streaming server worked for SysEx request/response but had issues with SDS:
-- MSG_SAMPLE_READ could send the Dump Request but the ACK timing was still too slow
-- The event queue architecture couldn't service ACKs fast enough
-- Later testing (April 10) confirmed the streaming port doesn't relay device responses for SDS uploads — dead end for that use case
+### Hardware results (April 5)
+Verified 34% improvement for SysEx request/response:
+- RPLIST: 565ms (was 865ms)
+- RPDATA: 794ms (was 1196ms)
+- Write: 572ms (was 874ms)
+
+### Rust bridge integration (April 5-6)
+- `MidiStreamClient` in `s2p_client.rs` — persistent TCP with lazy reconnect, TCP_NODELAY
+- Bridge tries streaming first, falls back to protobuf
+- Bug: connection was torn down on timeout/unexpected responses, causing reconnection overhead. Fixed by preserving connection on non-I/O errors.
+
+### MSG_SAMPLE_READ — SDS download attempt (April 6)
+1. First tried RSPACK (Akai opcode 0x0C) — device accepts but returns 0 bytes via MIDI_POLL
+2. Switched to standard SDS Dump Request — Dump Header arrives, ACK sent successfully
+3. **Data Packets do NOT arrive** via MIDI_POLL after ACK — the device sends them as device-initiated SCSI writes (target mode) which s2p can't process while servicing initiator-mode MIDI commands
+4. Added event queue with condvar to MidiProcessor for async data delivery — infrastructure correct but SDS Data Packets never arrive through the SCSI MIDI channel
+
+### Death of the streaming path (April 8)
+Two commits killed it:
+
+**`77b419e2` (April 8 21:49):** "eliminate duplicate SCSI MIDI paths" — the bridge had two MIDI paths: protobuf wrappers and raw CDB functions. The protobuf path treated CHECK CONDITION as fatal; the raw CDB path correctly ignored it. Multi-sample workflows broke because the protobuf path failed on status bytes. Also: SDS transfers disabled MIDI mode but the SysEx path never re-enabled it. Fix: delete entire protobuf MIDI layer, use raw CDBs exclusively.
+
+**`3ec5daa8` (April 8 22:57):** "use raw CDB path exclusively" — removed `MidiStreamClient` from the SysEx worker path. The streaming client returned stale or incorrectly formatted data after SDS transfers, causing nibble parse errors in the TypeScript client. Root cause never fully diagnosed — possibly leftover SDS data packets in the streaming server's buffer contaminated subsequent SysEx responses.
+
+### What remains (April 10)
+The `MidiStreamClient` code is still in `s2p_client.rs` (lines 413-623) but nothing calls it. The s2p streaming server is still compiled and runs on port 6870 but serves no purpose. Testing on April 10 confirmed the streaming port doesn't relay device ACK responses for SDS uploads — it only forwards client→device data. Filed for deletion as issue #183.
+
+### Lessons
+1. The 34% SysEx improvement was real but insufficient to justify the complexity
+2. The streaming server couldn't handle SDS because SDS data packets arrive as device-initiated SCSI operations (target mode), not as responses to initiator commands
+3. Stale data after SDS transfers was a persistent bug that was never root-caused — the workaround (use raw CDBs exclusively) was the right call
+4. The batching approach (April 10) achieved 9x speedup with far less complexity by staying on the CDB path
 
 ---
 

--- a/docs/1.0/001-IN-PROGRESS/library-ux/README.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/README.md
@@ -44,10 +44,29 @@ Align and improve library page UX across both the Roland S-330/S-550 editor and 
 | Phase 2: Upstream to editor-core | Complete | Context menu routing, headerSections, widened libraryHandle |
 | Phase 3: Migrate Roland to PluginLibraryBrowser | Complete | Both editors use same component, deleted 579-line bespoke |
 | Phase 4: UX polish on shared components | Mostly complete | 4.1-4.4 done; 4.5 keyboard nav deferred |
-| Phase 5: S3K Zone 3→4 promotion | In progress | Promote S3K programs to common area |
-| Phase 6: Shared useEditorDialogs | Stub | Next priority after Phase 5 |
+| Phase 5: S3K Zone 3→4 promotion | Complete | Promote S3K programs to common area |
+| Phase 6: Shared useEditorDialogs | Complete | Shared hook with WavLoaderStrategy |
+| Phase 7: Unify library operations | Complete | Shared useLibraryOperations hook |
+| Phase 8: Library UI e2e tests | Complete | Test IDs, helpers, bug fixes |
+| Phase 9: SCSI disk browser | Complete | Lazy metadata, context menus, drag-drop, loading indicators |
+| Phase 10: SDS optimization | Complete | Batched SDS 9x speedup (2.2 KB/s), bridge hardening |
+| Phase 11: Drag-drop workflows | Complete | Disk→library, disk→device, library→device with type filtering |
+| Phase 12: Common-area programs | Complete | Three library sections, expandable programs, sourceDevice schema |
+| Phase 13: ASPACK investigation | Blocked | 23.4 KB/s proven but multi-chunk + sample creation unsolved (#184) |
+
+## Related Issues
+
+- [#183](https://github.com/audiocontrol-org/audiocontrol/issues/183) — Delete dead MidiStreamClient (streaming port 6870)
+- [#184](https://github.com/audiocontrol-org/audiocontrol/issues/184) — ASPACK bulk sample transfer (10x faster than SDS)
+- [#185](https://github.com/audiocontrol-org/audiocontrol/issues/185) — Safari/iOS createWritable compatibility
+- [#186](https://github.com/audiocontrol-org/audiocontrol/pull/186) — PR: Library UX, SCSI disk browser, drag-drop, SDS batching
 
 ## Related Documentation
 
-- [SAMPLER-LIBRARY.md](/SAMPLER-LIBRARY.md) - Four-zone storage model and conversion boundaries
+- [SAMPLER-LIBRARY.md](/SAMPLER-LIBRARY.md) — Four-zone storage model and conversion boundaries
+- [S3000XL SysEx Protocol](../../s3000xl-editor/s3000xl-sysex-protocol.md) — Canonical protocol reference
+- [SCSI Sample Transfer Findings](../../scsi-sample-transfer/scsi-sample-data-findings.md) — ASPACK/RSPACK/SDS findings
+- [ASPACK Exploration Plan](../../scsi-sample-transfer/bulk-transfer-exploration-plan.md) — Systematic investigation plan
+- [SCSI-NOTES.md](/SCSI-NOTES.md) — Travel log of SCSI reverse engineering
+- [DEVELOPMENT-NOTES.md](/DEVELOPMENT-NOTES.md) — Session journal
 - [S3K Library Page Conformance](../../s3k-library-page/) - Prior effort (superseded by this feature)

--- a/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
@@ -412,11 +412,26 @@ Phase 5 (S3K Zone 3→4 promotion) — COMPLETE
 Phase 6 (shared useEditorDialogs) — COMPLETE
   6.1 -> 6.2 -> 6.3
 
-Phase 7 (unify library operations, after Phase 6)
+Phase 7 (unify library operations) — COMPLETE
   7.1 (shared hook) -> 7.2 (wire both editors) -> 7.3 (S3K LibraryPage extraction)
 
-Phase 8 (library UI e2e tests, after Phase 7)
+Phase 8 (library UI e2e tests) — COMPLETE
   8.1 (test IDs) -> 8.2 (test helpers) -> 8.3 (failing tests) -> 8.4 (fix bugs)
+
+Phase 9 (SCSI disk browser) — COMPLETE
+  Lazy metadata loading, context menus, drag-drop to library, loading indicators
+
+Phase 10 (SDS optimization) — COMPLETE
+  Batched SDS (20 packets, 9x speedup), bridge hardening, dynamic timeouts
+
+Phase 11 (drag-drop workflows) — COMPLETE
+  Disk→library, disk→device, library→device with type filtering, auto-send missing samples
+
+Phase 12 (common-area programs) — COMPLETE
+  Three library sections, expandable programs, sourceDevice schema fix
+
+Phase 13 (ASPACK bulk transfer) — BLOCKED on #184
+  23.4 KB/s proven but multi-chunk writes + sample creation unsolved
 ```
 
 ---


### PR DESCRIPTION
## Summary

Documentation updates from the April 9-10 library UX session:

- **DEVELOPMENT-NOTES.md** — structured session journal with correction categories ([COMPLEXITY], [UX], [FABRICATION], [DOCUMENTATION], [PROCESS]) and quantitative section. 20 corrections documented.
- **SCSI-NOTES.md** — complete travel log covering April 1-10: SCMP attempt, CDB 0x0D breakthrough, MESA II analysis, SheepShaver Gestalt gauntlet, streaming port lifecycle, SDS batching, ASPACK discovery.
- **Feature docs** — library-ux README.md and workplan.md updated through Phase 13 with new GitHub issues linked.
- **CLAUDE.md** — development journal policy requiring per-session entries.

## Test plan

- [x] All documentation is well-formed markdown
- [x] Workplan phases match README status table
- [x] SCSI-NOTES.md timestamps align with git commit history
- [x] Journal entry correction categories are consistently tagged