### PR TITLE
feat: ASPACK fast sample upload — 8x faster SCSI transfers

### DIFF
--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -13,6 +13,42 @@ Each correction is tagged by category for pattern analysis:
 
 ## 2026-04-10: Session Data Extraction, Analysis, and LLM Integration
 
+### Feature: library-ux
+### Worktree: audiocontrol-library-ux
+
+### Goal
+Integrate ASPACK fast upload end-to-end: bridge WebSocket endpoint, web editor wiring, bug fixes for timeouts and UI issues.
+
+### Accomplished
+- ASPACK bridge endpoint (`sample-upload-fast`) with stall-based timeout (99a23b6c)
+- Web editor wired to use ASPACK fast path instead of SDS (676c9b0b)
+- Stall-based timeout replaces fixed overall timeout — resets on every progress message, works for any sample size (99a23b6c)
+- Fixed ghost SendSampleDialog caused by `deviceSampleCount` in useEffect deps (99a23b6c)
+- Fixed device memory panel scroll cap — removed `max-h-48` (99a23b6c)
+- Fixed progress label, IPv6 proxy, drop event propagation, removed defensive sleep (c03dfe96)
+- Phase 13 (ASPACK fast upload) marked complete
+
+### Didn't Work
+- Initial ASPACK bridge timeout of 57s was too short for 573K-sample uploads (67s actual transfer time). The transfer completed on the device but the bridge killed the WebSocket connection. Root cause: throughput estimate (20 KB/s) was too optimistic vs actual (17.2 KB/s).
+
+### Course Corrections
+- [COMPLEXITY] User asked "why does the bridge set a single timeout for the entire transfer?" — prompted redesign from fixed timeout to stall-based timeout that resets on progress. Better design that works for any sample size.
+- [UX] User reported ghost dialog appearing after successful transfer — traced to `deviceSampleCount` dependency triggering effect re-run.
+- [UX] User reported device memory scroll pane artificially small — `max-h-48` was capping lists unnecessarily.
+
+### Quantitative
+- User messages: ~8
+- Commits: 4 (on feature branch, post-rebase)
+- User corrections: 3
+
+### Insights
+- Stall-based timeouts are universally better than estimated-duration timeouts for hardware transfers. The per-chunk progress messages are the natural heartbeat — if they stop, something is wrong.
+- useEffect dependency arrays need careful thought about what SHOULD vs SHOULDN'T re-trigger the effect. `deviceSampleCount` was logically relevant (initial value) but operationally destructive (re-triggers after transfer).
+
+---
+
+## 2026-04-10: Session Data Extraction, Analysis, and LLM Integration
+
 ### Feature: continuous-improvement
 ### Worktree: audiocontrol-continuous-improvement
 

--- a/SCSI-NOTES.md
+++ b/SCSI-NOTES.md
@@ -470,10 +470,43 @@ Always verify the sampler's protocol mode before running SDS operations. S3000 m
 
 ---
 
+## 2026-04-10 16:00 PDT: ASPACK End-to-End — Multi-Chunk, Bridge, Web Editor
+
+### Multi-chunk solved
+
+The multi-chunk ASPACK bug from the previous session was **the poll flag**. CDB 0x0D (poll) with flag 0x80 returns 0 bytes on the S3000XL. Flag 0x00 works. This was the opposite of what MESA II documentation suggested. Same applies to CDB 0x0C (send) — flag 0x00 required.
+
+### Sample creation
+
+ASPACK alone cannot create new samples. The minimum viable creation: 1 SDS dump header + 1 SDS data packet (40 samples of silence). This registers the sample in the RSLIST in ~700ms. Then ASPACK overwrites the data at any size.
+
+### Block boundary bug
+
+ASPACK rejects writes starting at exact multiples of 8192 samples (for N≥1). Chunk size 8191 avoids all boundaries. Single-chunk works for samples ≤60,000 (below any boundary).
+
+### Bridge integration
+
+New WebSocket endpoint `sample-upload-fast`: creates sample slot via minimal SDS, queries RSLIST for index, writes PCM via ASPACK chunks. Stall-based timeout replaces fixed overall timeout — resets 30s deadline on every progress message.
+
+### Throughput
+
+- Single chunk (≤60K samples): 23.4 KB/s
+- Multi-chunk (8191-sample chunks): ~17.2 KB/s (944ms per chunk including poll+ACK overhead)
+- vs SDS batched: 2.2 KB/s
+- Speedup: 8-10x over SDS
+
+### Bug fixes this session
+
+- **ASPACK timeout**: 573K-sample upload took 67s but bridge timeout was 57s. Transfer completed on device but bridge killed the connection. Fixed with stall-based timeout.
+- **Ghost dialog**: `deviceSampleCount` in SendSampleDialog's useEffect deps caused the effect to re-fire after `onTransferComplete` refreshed device state, resetting the dialog to "ready" phase.
+- **Device memory scroll**: `max-h-48` capped name lists at 192px regardless of available space.
+
+---
+
 ## Open Questions
 
-- Can ASPACK write at offset > 0? MESA II does it with 192-byte chunks. What's different about our encoding?
-- Is there an undocumented SysEx opcode for creating empty sample slots?
+- ~~Can ASPACK write at offset > 0?~~ **Yes** — poll flag 0x00 was the bug, not the offset.
+- ~~Is there an undocumented SysEx opcode for creating empty sample slots?~~ **No** — use minimal SDS (1 header + 1 data packet).
 - Can the S3000 protocol mode be toggled via SysEx?
 - Why does s2p take 113ms per SCSI CDB? Is there internal locking, logging, or device emulation overhead?
 - What does MESA's `SetSCSIMIDIMode` 84-byte config block contain?

--- a/docs/1.0/001-IN-PROGRESS/library-ux/README.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/README.md
@@ -52,7 +52,7 @@ Align and improve library page UX across both the Roland S-330/S-550 editor and 
 | Phase 10: SDS optimization | Complete | Batched SDS 9x speedup (2.2 KB/s), bridge hardening |
 | Phase 11: Drag-drop workflows | Complete | Disk→library, disk→device, library→device with type filtering |
 | Phase 12: Common-area programs | Complete | Three library sections, expandable programs, sourceDevice schema |
-| Phase 13: ASPACK investigation | Blocked | 23.4 KB/s proven but multi-chunk + sample creation unsolved (#184) |
+| Phase 13: ASPACK fast upload | Complete | Multi-chunk solved (poll flag 0x00), sample creation via minimal SDS, bridge + web editor integrated (#184) |
 
 ## Related Issues
 

--- a/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/library-ux/workplan.md
@@ -430,8 +430,9 @@ Phase 11 (drag-drop workflows) — COMPLETE
 Phase 12 (common-area programs) — COMPLETE
   Three library sections, expandable programs, sourceDevice schema fix
 
-Phase 13 (ASPACK bulk transfer) — BLOCKED on #184
-  23.4 KB/s proven but multi-chunk writes + sample creation unsolved
+Phase 13 (ASPACK fast upload) — COMPLETE
+  Multi-chunk solved (poll flag 0x00 not 0x80), sample creation via minimal SDS,
+  bridge WebSocket endpoint, web editor integrated, stall-based timeouts
 ```
 
 ---

--- a/docs/1.0/scsi-sample-transfer/scsi-sample-data-findings.md
+++ b/docs/1.0/scsi-sample-transfer/scsi-sample-data-findings.md
@@ -92,7 +92,10 @@ F0 47 cc 0D 48 [sample_num 4 nibbles] [offset 8 nibbles] [count 8 nibbles] [data
 - Each 16-bit PCM sample is 4 nibbles (LE nibble pairs)
 - Device returns REPLY (opcode 0x16, status 0x01) on success
 - **Cannot create new samples** — only overwrites data in existing sample slots
-- **Multi-chunk writes fail** — writing at offset > 0 returns empty reply. Only offset=0 works reliably with a single large chunk.
+- **Multi-chunk writes work** but only within the sample's allocated memory. Writing beyond the allocated length returns empty reply. Failure occurs consistently at the allocation boundary (e.g., offset 8448 for a sample created with ~8000 samples).
+- **Single-chunk writes can exceed allocated length** — sending the entire sample in one ASPACK appears to trigger reallocation. A 44100-sample single-chunk write succeeds even on a sample originally allocated smaller.
+- **CDB poll flag must be 0x00** — using flag `$80` on CDB 0x0D (Data Byte Enquiry) returns 0 bytes. This was the cause of the original "multi-chunk fails" bug. The S3000XL only reports pending bytes with flag `$00`.
+- **CDB send flag must be 0x00** — using flag `$80` on CDB 0x0C (Send MIDI Data) causes the device to not generate a REPLY at all. MESA documentation says `$80` means "reply expected" but the S3000XL behaves opposite — `$00` is required for ASPACK.
 
 Throughput (via raw SCSI CDBs, MIDI mode kept enabled):
 

--- a/docs/1.0/scsi-sample-transfer/scsi-sample-data-findings.md
+++ b/docs/1.0/scsi-sample-transfer/scsi-sample-data-findings.md
@@ -92,10 +92,19 @@ F0 47 cc 0D 48 [sample_num 4 nibbles] [offset 8 nibbles] [count 8 nibbles] [data
 - Each 16-bit PCM sample is 4 nibbles (LE nibble pairs)
 - Device returns REPLY (opcode 0x16, status 0x01) on success
 - **Cannot create new samples** — only overwrites data in existing sample slots
-- **Multi-chunk writes work** but only within the sample's allocated memory. Writing beyond the allocated length returns empty reply. Failure occurs consistently at the allocation boundary (e.g., offset 8448 for a sample created with ~8000 samples).
-- **Single-chunk writes can exceed allocated length** — sending the entire sample in one ASPACK appears to trigger reallocation. A 44100-sample single-chunk write succeeds even on a sample originally allocated smaller.
-- **CDB poll flag must be 0x00** — using flag `$80` on CDB 0x0D (Data Byte Enquiry) returns 0 bytes. This was the cause of the original "multi-chunk fails" bug. The S3000XL only reports pending bytes with flag `$00`.
-- **CDB send flag must be 0x00** — using flag `$80` on CDB 0x0C (Send MIDI Data) causes the device to not generate a REPLY at all. MESA documentation says `$80` means "reply expected" but the S3000XL behaves opposite — `$00` is required for ASPACK.
+- **Multi-chunk writes work** — use chunk sizes that avoid exact Akai block boundaries (multiples of 8192 samples). The device rejects ASPACK writes starting at offset N×8192 (for N≥1). Offset 0 works, offset 8191 works, offset 8193 works, but offset 8192 fails. Use chunk size 8191 or any size coprime with 8192.
+- **Block boundary bug:** The S3000XL rejects ASPACK at exact block boundaries (8192, 16384, 24576, ...) but accepts offset ±1. This is consistent across all block multiples tested (1-5). Offset 0 is the exception — it always works.
+- **Single-chunk writes can exceed allocated length** — sending the entire sample in one ASPACK appears to trigger reallocation.
+- **CDB poll flag must be 0x00** — using flag `$80` on CDB 0x0D (Data Byte Enquiry) returns 0 bytes. This was the cause of the original "multi-chunk fails" bug.
+- **CDB send flag must be 0x00** — using flag `$80` on CDB 0x0C (Send MIDI Data) causes the device to not generate a REPLY at all.
+
+### Multi-Chunk Throughput (block-boundary-aware)
+
+| Chunk size | Chunks for 44100 | Time | Throughput |
+|-----------|-----------------|------|-----------|
+| 193 (coprime) | 229 | 83s | 1.0 KB/s |
+| 8191 (block-1) | 6 | 5.4s | **16.1 KB/s** |
+| 44100 (single) | 1 | 3.7s | **23.3 KB/s** |
 
 ### Maximum Message Size
 

--- a/docs/1.0/scsi-sample-transfer/scsi-sample-data-findings.md
+++ b/docs/1.0/scsi-sample-transfer/scsi-sample-data-findings.md
@@ -97,6 +97,20 @@ F0 47 cc 0D 48 [sample_num 4 nibbles] [offset 8 nibbles] [count 8 nibbles] [data
 - **CDB poll flag must be 0x00** — using flag `$80` on CDB 0x0D (Data Byte Enquiry) returns 0 bytes. This was the cause of the original "multi-chunk fails" bug. The S3000XL only reports pending bytes with flag `$00`.
 - **CDB send flag must be 0x00** — using flag `$80` on CDB 0x0C (Send MIDI Data) causes the device to not generate a REPLY at all. MESA documentation says `$80` means "reply expected" but the S3000XL behaves opposite — `$00` is required for ASPACK.
 
+### Maximum Message Size
+
+The maximum single-chunk ASPACK message is **~262 KB SysEx** (67,000 samples = 131 KB PCM). Messages larger than ~264 KB cause s2p SCSI timeout.
+
+This allows single-chunk transfer of samples up to:
+- 44.1kHz: ~1.52 seconds (67,000 samples)
+- 22.05kHz: ~3.04 seconds (67,000 samples)
+
+For longer samples, multi-chunk writes work if the sample's memory is pre-allocated to the correct size (via SDS or other mechanism).
+
+The 262 KB limit is likely a buffer constraint in s2p's SCSI CDB 0x0C handler or the S3000XL's MIDI-over-SCSI receive buffer.
+
+### Throughput
+
 Throughput (via raw SCSI CDBs, MIDI mode kept enabled):
 
 | Chunk size | Per-chunk | Throughput |

--- a/modules/akai-s3k-editor/src/components/library/DeviceMemoryPanel.tsx
+++ b/modules/akai-s3k-editor/src/components/library/DeviceMemoryPanel.tsx
@@ -144,6 +144,7 @@ export function DeviceMemoryPanel({
         }}
         onDrop={(e) => {
           e.preventDefault();
+          e.stopPropagation();
           setProgramDropOver(false);
           // Handle library item drops
           const libRaw = e.dataTransfer.getData(LIBRARY_ITEM_MIME);
@@ -197,6 +198,7 @@ export function DeviceMemoryPanel({
         }}
         onDrop={(e) => {
           e.preventDefault();
+          e.stopPropagation();
           setSampleDropOver(false);
           // Handle library item drops
           const libRaw = e.dataTransfer.getData(LIBRARY_ITEM_MIME);

--- a/modules/akai-s3k-editor/src/components/library/DeviceMemoryPanel.tsx
+++ b/modules/akai-s3k-editor/src/components/library/DeviceMemoryPanel.tsx
@@ -57,7 +57,7 @@ function NameList({
       <h4 className="text-sm font-semibold text-gray-400 uppercase tracking-wide mb-1">
         {title} ({names.length})
       </h4>
-      <ul className="max-h-48 overflow-y-auto space-y-px">
+      <ul className="overflow-y-auto space-y-px">
         {names.map((name, index) => {
           const isSelected = selectedType === type && selectedIndex === index;
           return (

--- a/modules/akai-s3k-editor/src/components/library/SendSampleDialog.tsx
+++ b/modules/akai-s3k-editor/src/components/library/SendSampleDialog.tsx
@@ -136,8 +136,6 @@ export function SendSampleDialog({
       await sendToDevice(targetSampleNumber, wavInfo.samples, wavInfo.sampleRate, sampleName);
       console.log(`[SendSampleDialog] sendToDevice resolved — setting phase to success`);
       setPhase('success');
-      // Give device time to commit the sample before refreshing
-      await new Promise((r) => setTimeout(r, 1500));
       await onTransferComplete();
     } catch {
       setPhase('error');

--- a/modules/akai-s3k-editor/src/components/library/SendSampleDialog.tsx
+++ b/modules/akai-s3k-editor/src/components/library/SendSampleDialog.tsx
@@ -94,7 +94,6 @@ export function SendSampleDialog({
     setPhase('loading');
     setWavInfo(null);
     setLoadError(null);
-    setTargetSampleNumber(deviceSampleCount);
     clearError();
 
     let cancelled = false;
@@ -124,7 +123,11 @@ export function SendSampleDialog({
 
     void load();
     return () => { cancelled = true; };
-  }, [open, libraryRoot, sampleName, samplePath, client, deviceSampleCount, clearError]);
+    // Note: deviceSampleCount intentionally excluded — the effect queries the
+    // authoritative count from the device. Including it would re-trigger the
+    // effect after a successful transfer (which refreshes device state).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, libraryRoot, sampleName, samplePath, client, clearError]);
 
   const handleSend = useCallback(async () => {
     if (!wavInfo) return;

--- a/modules/akai-s3k-editor/src/components/ui/SdsTransferProgress.tsx
+++ b/modules/akai-s3k-editor/src/components/ui/SdsTransferProgress.tsx
@@ -45,7 +45,7 @@ export function SdsProgressBar({ progress, direction }: SdsProgressBarProps): JS
   const remainingBytes = progress ? progress.bytesTotal - progress.bytesSent : 0;
   const etaMs = bytesPerMs > 0 ? remainingBytes / bytesPerMs : 0;
 
-  const label = direction === 'send' ? 'Sending' : 'Receiving';
+  const label = direction === 'send' ? 'Sending sample to device' : 'Receiving sample from device';
 
   return (
     <div className="space-y-2">
@@ -71,7 +71,7 @@ export function SdsProgressBar({ progress, direction }: SdsProgressBarProps): JS
           {elapsed > 1000 && `${formatDuration(elapsed)} elapsed`}
           {etaMs > 1000 && ` \u2022 ~${formatDuration(etaMs)} remaining`}
         </span>
-        <span>{label} sample via SDS</span>
+        <span>{label}</span>
       </div>
     </div>
   );

--- a/modules/akai-s3k-editor/vite.config.ts
+++ b/modules/akai-s3k-editor/vite.config.ts
@@ -34,7 +34,8 @@ export default defineConfig({
     allowedHosts: ['orion-m1', 'orion-m4'],
     proxy: {
       '/scsi-bridge': {
-        target: 'http://s3k.local:7033',
+        // Use IPv4 explicitly — s3k.local resolves to IPv6 which times out
+        target: 'http://10.0.0.57:7033',
         changeOrigin: true,
         rewrite: (p) => p.replace(/^\/scsi-bridge/, ''),
         ws: true,
@@ -44,7 +45,8 @@ export default defineConfig({
   preview: {
     proxy: {
       '/scsi-bridge': {
-        target: 'http://s3k.local:7033',
+        // Use IPv4 explicitly — s3k.local resolves to IPv6 which times out
+        target: 'http://10.0.0.57:7033',
         changeOrigin: true,
         rewrite: (p) => p.replace(/^\/scsi-bridge/, ''),
         ws: true,

--- a/modules/e2e-infra/src/node/lib/test-aspack-bridge.ts
+++ b/modules/e2e-infra/src/node/lib/test-aspack-bridge.ts
@@ -1,0 +1,91 @@
+/**
+ * Test ASPACK upload through the bridge WebSocket (sample-upload-fast).
+ *
+ * Run: E2E_SCSI_BRIDGE_URL=http://10.0.0.57:7033 tsx modules/e2e-infra/src/node/lib/test-aspack-bridge.ts
+ */
+
+import WebSocket from 'ws';
+
+const BRIDGE_URL = process.env.E2E_SCSI_BRIDGE_URL ?? 'http://10.0.0.57:7033';
+const SAMPLE_RATE = 44100;
+const SAMPLE_COUNT = 44100; // 1 second
+
+async function main() {
+  const samples: number[] = [];
+  for (let i = 0; i < SAMPLE_COUNT; i++) {
+    samples.push(Math.round(Math.sin(2 * Math.PI * 440 * i / SAMPLE_RATE) * 16000));
+  }
+
+  const wsUrl = BRIDGE_URL.replace(/^http/, 'ws') + '/sds/stream';
+  console.log(`\n=== ASPACK Bridge Upload Test ===`);
+  console.log(`Bridge: ${wsUrl}`);
+  console.log(`Sample: ${SAMPLE_COUNT} samples (${(SAMPLE_COUNT * 2 / 1024).toFixed(1)} KB)\n`);
+
+  const startTime = performance.now();
+  let progressCount = 0;
+
+  await new Promise<void>((resolve, reject) => {
+    const ws = new WebSocket(wsUrl);
+    const timeout = setTimeout(() => {
+      ws.close();
+      reject(new Error('ASPACK upload timed out after 60s'));
+    }, 60_000);
+
+    ws.on('open', () => {
+      console.log('WebSocket connected, sending sample-upload-fast...');
+      ws.send(JSON.stringify({
+        type: 'sample-upload-fast',
+        target_id: 6,
+        sample_number: 80,
+        channel: 0,
+        sample_rate: SAMPLE_RATE,
+        samples,
+      }));
+    });
+
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      switch (msg.type) {
+        case 'upload-progress':
+          progressCount++;
+          if (progressCount <= 3 || progressCount % 5 === 0) {
+            const pct = msg.total > 0 ? Math.round(msg.transferred / msg.total * 100) : 0;
+            console.log(`  Progress: ${msg.transferred}/${msg.total} (${pct}%)`);
+          }
+          break;
+        case 'upload-complete':
+          clearTimeout(timeout);
+          ws.close();
+          resolve();
+          break;
+        case 'sample-error':
+          clearTimeout(timeout);
+          ws.close();
+          reject(new Error(msg.error));
+          break;
+      }
+    });
+
+    ws.on('error', (err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
+  });
+
+  const totalMs = performance.now() - startTime;
+  const throughput = (SAMPLE_COUNT * 2) / (totalMs / 1000);
+
+  console.log(`\n=== Results ===`);
+  console.log(`Total time: ${Math.round(totalMs)}ms`);
+  console.log(`Throughput: ${(throughput / 1024).toFixed(1)} KB/s`);
+  console.log(`Progress updates: ${progressCount}`);
+  console.log(`\nComparison:`);
+  console.log(`  Batched SDS:  2.2 KB/s (~40s for this sample)`);
+  console.log(`  ASPACK:       ${(throughput / 1024).toFixed(1)} KB/s (${(totalMs / 1000).toFixed(1)}s)`);
+  console.log(`  Speedup:      ${(throughput / 1024 / 2.2).toFixed(1)}x`);
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/modules/e2e-infra/src/node/lib/test-aspack-max-size.ts
+++ b/modules/e2e-infra/src/node/lib/test-aspack-max-size.ts
@@ -1,0 +1,164 @@
+/**
+ * Find the maximum single-chunk ASPACK message size the S3000XL accepts.
+ *
+ * The device accepts 44100 samples (176KB SysEx) in one chunk. How far can we go?
+ * Binary search for the ceiling.
+ *
+ * Run: E2E_SCSI_BRIDGE_URL=http://10.0.0.57:7033 tsx modules/e2e-infra/src/node/lib/test-aspack-max-size.ts
+ */
+
+const BRIDGE_URL = process.env.E2E_SCSI_BRIDGE_URL ?? 'http://10.0.0.57:7033';
+const TARGET_ID = 6;
+
+async function scsiExec(cdb: number[], dataOut: number[] = [], expectedIn = 0): Promise<number[]> {
+  const resp = await fetch(`${BRIDGE_URL}/scsi/exec`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target_id: TARGET_ID, cdb, data_out: dataOut, expected_data_in: expectedIn }),
+  });
+  if (!resp.ok) throw new Error(`scsi/exec HTTP ${resp.status}: ${await resp.text()}`);
+  return ((await resp.json()) as { data_in: number[] }).data_in ?? [];
+}
+
+async function midiEnable(): Promise<void> { await scsiExec([0x09, 0x00, 0x01, 0x00, 0x00, 0x00]); }
+async function midiDisable(): Promise<void> { await scsiExec([0x09, 0x00, 0x00, 0x00, 0x00, 0x00]); }
+
+async function midiSend(data: number[]): Promise<void> {
+  const len = data.length;
+  await scsiExec(
+    [0x0C, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00],
+    data, 0,
+  );
+}
+
+async function midiPoll(): Promise<number> {
+  const d = await scsiExec([0x0D, 0x00, 0x00, 0x00, 0x00, 0x00], [], 3);
+  if (d.length >= 3) return (d[0] << 16) | (d[1] << 8) | d[2];
+  return 0;
+}
+
+async function midiRead(len: number): Promise<number[]> {
+  return scsiExec([0x0E, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], [], len);
+}
+
+async function pollForReply(): Promise<number[]> {
+  for (let i = 0; i < 30; i++) {
+    const pending = await midiPoll();
+    if (pending > 0) return midiRead(pending);
+  }
+  return [];
+}
+
+function toNibbles(value: number, byteCount: number): number[] {
+  const nibbles: number[] = [];
+  for (let i = 0; i < byteCount; i++) {
+    const byte = (value >> (i * 8)) & 0xFF;
+    nibbles.push(byte & 0x0F, (byte >> 4) & 0x0F);
+  }
+  return nibbles;
+}
+
+function buildASPACK(sampleIdx: number, sampleCount: number): number[] {
+  const msg = [0xF0, 0x47, 0x00, 0x0D, 0x48,
+    ...toNibbles(sampleIdx, 2),
+    ...toNibbles(0, 4),              // offset = 0
+    ...toNibbles(sampleCount, 4),    // count
+  ];
+  // Fill with a simple pattern (alternating values)
+  for (let i = 0; i < sampleCount; i++) {
+    const val = (i % 256);
+    msg.push(val & 0x0F, (val >> 4) & 0x0F, 0, 0);
+  }
+  msg.push(0xF7);
+  return msg;
+}
+
+async function testSize(sampleCount: number, sampleIdx: number): Promise<boolean> {
+  const msgSize = 5 + 4 + 8 + 8 + sampleCount * 4 + 1; // header + nibbles + F7
+  const pcmBytes = sampleCount * 2;
+
+  process.stdout.write(`  ${sampleCount} samples (${(pcmBytes / 1024).toFixed(1)} KB PCM, ${(msgSize / 1024).toFixed(1)} KB SysEx)... `);
+
+  await midiEnable();
+  const msg = buildASPACK(sampleIdx, sampleCount);
+  const t0 = performance.now();
+
+  try {
+    await midiSend(msg);
+  } catch (err) {
+    console.log(`SEND FAILED: ${err}`);
+    await midiDisable();
+    return false;
+  }
+
+  const reply = await pollForReply();
+  const ms = performance.now() - t0;
+  await midiDisable();
+
+  if (reply.length >= 4 && reply[3] === 0x16) {
+    const throughput = pcmBytes / (ms / 1000) / 1024;
+    console.log(`OK (${Math.round(ms)}ms, ${throughput.toFixed(1)} KB/s)`);
+    return true;
+  } else {
+    console.log(`FAILED (reply: ${reply.length} bytes)`);
+    return false;
+  }
+}
+
+async function main() {
+  console.log('=== ASPACK Maximum Message Size Test ===\n');
+
+  // Use last sample on device
+  const listResp = await fetch(`${BRIDGE_URL}/sds/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: [0xF0, 0x47, 0x00, 0x04, 0x48, 0xF7] }),
+  });
+  const listJson = await listResp.json() as { response?: number[] };
+  const sampleCount = listJson.response && listJson.response.length > 6
+    ? Math.floor((listJson.response.length - 6) / 24) : 0;
+  if (sampleCount === 0) {
+    console.error('No samples on device.');
+    return;
+  }
+  const sIdx = sampleCount - 1;
+  console.log(`Using sample index ${sIdx}\n`);
+
+  // Test increasing sizes
+  console.log('--- Linear sweep ---');
+  const sizes = [
+    66000,    // known to work
+    67000,
+    67500,
+    68000,
+    68500,
+    69000,
+    69500,
+    70000,    // known to fail
+  ];
+
+  let lastSuccess = 0;
+  for (const size of sizes) {
+    const ok = await testSize(size, sIdx);
+    if (ok) {
+      lastSuccess = size;
+    } else {
+      break;
+    }
+  }
+
+  console.log(`\n--- Result ---`);
+  console.log(`Last successful: ${lastSuccess} samples (${(lastSuccess * 2 / 1024).toFixed(1)} KB PCM)`);
+  console.log(`SysEx message size: ${((lastSuccess * 4 + 26) / 1024).toFixed(1)} KB`);
+
+  if (lastSuccess >= 250000) {
+    console.log('Ceiling not found — try larger sizes.');
+  }
+
+  console.log('\n=== Done ===');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/modules/e2e-infra/src/node/lib/test-aspack-multichunk-preallocated.ts
+++ b/modules/e2e-infra/src/node/lib/test-aspack-multichunk-preallocated.ts
@@ -1,0 +1,164 @@
+/**
+ * Test multi-chunk ASPACK on a pre-allocated sample.
+ *
+ * Hypothesis: multi-chunk fails because writing beyond the sample's
+ * allocated memory returns empty reply. If we first allocate the
+ * full size via a single-chunk ASPACK (which triggers reallocation),
+ * then multi-chunk should work across the entire range.
+ *
+ * Run: E2E_SCSI_BRIDGE_URL=http://10.0.0.57:7033 tsx modules/e2e-infra/src/node/lib/test-aspack-multichunk-preallocated.ts
+ */
+
+const BRIDGE_URL = process.env.E2E_SCSI_BRIDGE_URL ?? 'http://10.0.0.57:7033';
+const TARGET_ID = 6;
+const TOTAL_SAMPLES = 44100;
+
+async function scsiExec(cdb: number[], dataOut: number[] = [], expectedIn = 0): Promise<number[]> {
+  const resp = await fetch(`${BRIDGE_URL}/scsi/exec`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target_id: TARGET_ID, cdb, data_out: dataOut, expected_data_in: expectedIn }),
+  });
+  if (!resp.ok) throw new Error(`scsi/exec HTTP ${resp.status}: ${await resp.text()}`);
+  return ((await resp.json()) as { data_in: number[] }).data_in ?? [];
+}
+
+async function midiEnable(): Promise<void> { await scsiExec([0x09, 0x00, 0x01, 0x00, 0x00, 0x00]); }
+async function midiDisable(): Promise<void> { await scsiExec([0x09, 0x00, 0x00, 0x00, 0x00, 0x00]); }
+
+async function midiSend(data: number[]): Promise<void> {
+  const len = data.length;
+  await scsiExec([0x0C, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], data, 0);
+}
+
+async function midiPoll(): Promise<number> {
+  const d = await scsiExec([0x0D, 0x00, 0x00, 0x00, 0x00, 0x00], [], 3);
+  if (d.length >= 3) return (d[0] << 16) | (d[1] << 8) | d[2];
+  return 0;
+}
+
+async function midiRead(len: number): Promise<number[]> {
+  return scsiExec([0x0E, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], [], len);
+}
+
+async function pollForReply(): Promise<number[]> {
+  for (let i = 0; i < 30; i++) {
+    const pending = await midiPoll();
+    if (pending > 0) return midiRead(pending);
+  }
+  return [];
+}
+
+function toNibbles(value: number, byteCount: number): number[] {
+  const nibbles: number[] = [];
+  for (let i = 0; i < byteCount; i++) {
+    const byte = (value >> (i * 8)) & 0xFF;
+    nibbles.push(byte & 0x0F, (byte >> 4) & 0x0F);
+  }
+  return nibbles;
+}
+
+function sampleToNibbles(sample: number): number[] {
+  const raw = sample & 0xFFFF;
+  return [raw & 0x0F, (raw >> 4) & 0x0F, (raw >> 8) & 0x0F, (raw >> 12) & 0x0F];
+}
+
+function buildASPACK(sampleIdx: number, offset: number, samples: Int16Array, start: number, count: number): number[] {
+  const msg = [0xF0, 0x47, 0x00, 0x0D, 0x48,
+    ...toNibbles(sampleIdx, 2),
+    ...toNibbles(offset, 4),
+    ...toNibbles(count, 4),
+  ];
+  for (let i = 0; i < count; i++) {
+    const s = start + i < samples.length ? samples[start + i] : 0;
+    msg.push(...sampleToNibbles(s));
+  }
+  msg.push(0xF7);
+  return msg;
+}
+
+async function getSampleCount(): Promise<number> {
+  const resp = await fetch(`${BRIDGE_URL}/sds/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: [0xF0, 0x47, 0x00, 0x04, 0x48, 0xF7] }),
+  });
+  const json = await resp.json() as { response?: number[] };
+  const data = json.response ?? [];
+  if (data.length < 6) return 0;
+  return Math.floor((data.length - 6) / 24);
+}
+
+async function main() {
+  console.log('=== ASPACK Multi-Chunk on Pre-Allocated Sample ===\n');
+
+  const samples = new Int16Array(TOTAL_SAMPLES);
+  for (let i = 0; i < TOTAL_SAMPLES; i++) {
+    samples[i] = Math.round(Math.sin(2 * Math.PI * 440 * i / 44100) * 16000);
+  }
+
+  const count = await getSampleCount();
+  if (count === 0) { console.error('No samples on device.'); return; }
+  const sIdx = count - 1;
+  console.log(`Samples on device: ${count}. Using index ${sIdx}.\n`);
+
+  // Step 1: Pre-allocate by writing full sample in single chunk
+  console.log(`Step 1: Single-chunk ASPACK (${TOTAL_SAMPLES} samples) to pre-allocate memory...`);
+  await midiEnable();
+  const allocMsg = buildASPACK(sIdx, 0, samples, 0, TOTAL_SAMPLES);
+  const t0 = performance.now();
+  await midiSend(allocMsg);
+  const allocReply = await pollForReply();
+  const allocMs = performance.now() - t0;
+  await midiDisable();
+
+  if (allocReply.length >= 4 && allocReply[3] === 0x16) {
+    console.log(`  OK — ${Math.round(allocMs)}ms\n`);
+  } else {
+    console.error(`  Pre-allocation FAILED. Aborting.`);
+    return;
+  }
+
+  // Step 2: Multi-chunk write across the full range
+  for (const chunkSize of [192, 1536, 4096]) {
+    const chunks = Math.ceil(TOTAL_SAMPLES / chunkSize);
+    console.log(`Step 2: Multi-chunk (${chunkSize} samples/chunk, ${chunks} chunks)...`);
+
+    await midiEnable();
+    let offset = 0;
+    let failed = false;
+    const t1 = performance.now();
+
+    for (let i = 0; i < chunks; i++) {
+      const cnt = Math.min(chunkSize, TOTAL_SAMPLES - offset);
+      const msg = buildASPACK(sIdx, offset, samples, offset, cnt);
+
+      await midiSend(msg);
+      const reply = await pollForReply();
+
+      if (reply.length >= 4 && reply[3] === 0x16) {
+        // OK
+      } else {
+        console.log(`  FAILED at chunk ${i + 1}/${chunks}, offset=${offset}`);
+        failed = true;
+        break;
+      }
+      offset += cnt;
+    }
+
+    const totalMs = performance.now() - t1;
+    await midiDisable();
+
+    if (!failed) {
+      const throughput = (TOTAL_SAMPLES * 2) / (totalMs / 1000) / 1024;
+      console.log(`  ✓ ALL ${chunks} CHUNKS SUCCEEDED — ${Math.round(totalMs)}ms, ${throughput.toFixed(1)} KB/s\n`);
+    }
+  }
+
+  console.log('=== Done ===');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/modules/e2e-infra/src/node/lib/test-aspack-multichunk.ts
+++ b/modules/e2e-infra/src/node/lib/test-aspack-multichunk.ts
@@ -1,0 +1,188 @@
+/**
+ * Phase 1: Test ASPACK multi-chunk writes with MESA-style protocol fixes.
+ *
+ * Tests systematically:
+ * 1. Baseline: flag=0x00, no drain (known to fail at offset > 0)
+ * 2. CDB flag byte $80 on send
+ * 3. Drain pending data between chunks
+ * 4. Flag $80 + drain (MESA's full protocol)
+ * 5. Opcode 0x0B (SDATA) instead of 0x0D (ASPACK)
+ *
+ * Run: E2E_SCSI_BRIDGE_URL=http://s3k.local:7033 tsx modules/e2e-infra/src/node/lib/test-aspack-multichunk.ts
+ */
+
+const BRIDGE_URL = process.env.E2E_SCSI_BRIDGE_URL ?? 'http://s3k.local:7033';
+const TARGET_ID = 6;
+const CHUNK_SIZE = 192; // MESA's chunk size
+const TOTAL_SAMPLES = 1000;
+
+async function scsiExec(cdb: number[], dataOut: number[] = [], expectedIn = 0): Promise<number[]> {
+  const resp = await fetch(`${BRIDGE_URL}/scsi/exec`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target_id: TARGET_ID, cdb, data_out: dataOut, expected_data_in: expectedIn }),
+  });
+  if (!resp.ok) throw new Error(`scsi/exec HTTP ${resp.status}: ${await resp.text()}`);
+  return ((await resp.json()) as { data_in: number[] }).data_in ?? [];
+}
+
+async function midiEnable(): Promise<void> { await scsiExec([0x09, 0x00, 0x01, 0x00, 0x00, 0x00]); }
+async function midiDisable(): Promise<void> { await scsiExec([0x09, 0x00, 0x00, 0x00, 0x00, 0x00]); }
+
+async function midiSend(data: number[], flag = 0x00): Promise<void> {
+  const len = data.length;
+  await scsiExec(
+    [0x0C, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, flag],
+    data, 0,
+  );
+}
+
+async function midiPoll(): Promise<number> {
+  // Flag 0x00 for data count query. Flag 0x80 returns 0 on S3000XL.
+  const d = await scsiExec([0x0D, 0x00, 0x00, 0x00, 0x00, 0x00], [], 3);
+  if (d.length >= 3) return (d[0] << 16) | (d[1] << 8) | d[2];
+  return 0;
+}
+
+async function midiRead(len: number): Promise<number[]> {
+  return scsiExec([0x0E, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], [], len);
+}
+
+async function drain(): Promise<void> {
+  const pending = await midiPoll();
+  if (pending > 0) {
+    const data = await midiRead(pending);
+    console.log(`    drained ${data.length} bytes`);
+  }
+}
+
+async function pollForReply(maxAttempts = 10): Promise<number[]> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const pending = await midiPoll();
+    if (pending > 0) {
+      return midiRead(pending);
+    }
+  }
+  return [];
+}
+
+function toNibbles(value: number, byteCount: number): number[] {
+  const nibbles: number[] = [];
+  for (let i = 0; i < byteCount; i++) {
+    const byte = (value >> (i * 8)) & 0xFF;
+    nibbles.push(byte & 0x0F, (byte >> 4) & 0x0F);
+  }
+  return nibbles;
+}
+
+function sampleToNibbles(sample: number): number[] {
+  const raw = sample & 0xFFFF;
+  return [raw & 0x0F, (raw >> 4) & 0x0F, (raw >> 8) & 0x0F, (raw >> 12) & 0x0F];
+}
+
+function buildPacket(opcode: number, sampleIdx: number, offset: number, samples: Int16Array, start: number, count: number): number[] {
+  const msg = [
+    0xF0, 0x47, 0x00, opcode, 0x48,
+    ...toNibbles(sampleIdx, 2),
+    ...toNibbles(offset, 4),
+    ...toNibbles(count, 4),
+  ];
+  for (let i = 0; i < count; i++) {
+    const s = start + i < samples.length ? samples[start + i] : 0;
+    msg.push(...sampleToNibbles(s));
+  }
+  msg.push(0xF7);
+  return msg;
+}
+
+interface TestConfig {
+  name: string;
+  opcode: number;
+  sendFlag: number;
+  drainBetween: boolean;
+}
+
+async function runTest(config: TestConfig, sampleIdx: number, samples: Int16Array): Promise<boolean> {
+  console.log(`\n--- ${config.name} ---`);
+  const chunks = Math.ceil(TOTAL_SAMPLES / CHUNK_SIZE);
+
+  await midiEnable();
+  if (config.drainBetween) await drain();
+
+  let offset = 0;
+  let success = true;
+
+  for (let i = 0; i < chunks; i++) {
+    const count = Math.min(CHUNK_SIZE, TOTAL_SAMPLES - offset);
+    const msg = buildPacket(config.opcode, sampleIdx, offset, samples, offset, count);
+
+    await midiSend(msg, config.sendFlag);
+    const reply = await pollForReply();
+
+    if (reply.length >= 4 && reply[3] === 0x16) {
+      const statusByte = reply.length >= 6 ? reply[5] : -1;
+      console.log(`  Chunk ${i + 1}/${chunks}: offset=${offset} count=${count} — OK (status=${statusByte})`);
+    } else {
+      console.log(`  Chunk ${i + 1}/${chunks}: offset=${offset} — FAILED (reply: [${reply.slice(0, 10).map(b => b.toString(16).padStart(2, '0')).join(' ')}])`);
+      success = false;
+      break;
+    }
+
+    offset += count;
+
+    if (config.drainBetween && i < chunks - 1) {
+      await drain();
+    }
+  }
+
+  await midiDisable();
+  return success;
+}
+
+async function main() {
+  console.log('=== ASPACK Multi-Chunk Test (Phase 1) ===');
+  console.log(`Chunk size: ${CHUNK_SIZE}, Total: ${TOTAL_SAMPLES} samples\n`);
+
+  const samples = new Int16Array(TOTAL_SAMPLES);
+  for (let i = 0; i < TOTAL_SAMPLES; i++) {
+    samples[i] = Math.round(Math.sin(2 * Math.PI * 440 * i / 44100) * 16000);
+  }
+
+  // Verify device has samples
+  const listResp = await fetch(`${BRIDGE_URL}/sds/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: [0xF0, 0x47, 0x00, 0x04, 0x48, 0xF7] }),
+  });
+  const listJson = await listResp.json() as { response?: number[] };
+  const sampleCount = listJson.response && listJson.response.length > 6
+    ? Math.floor((listJson.response.length - 6) / 24) : 0;
+
+  if (sampleCount === 0) {
+    console.error('No samples on device. Send one via SDS first.');
+    return;
+  }
+  console.log(`Samples on device: ${sampleCount}. Writing to index 0.\n`);
+
+  const tests: TestConfig[] = [
+    { name: 'Baseline (flag=0x00, no drain)', opcode: 0x0D, sendFlag: 0x00, drainBetween: false },
+    { name: 'Flag $80 on send', opcode: 0x0D, sendFlag: 0x80, drainBetween: false },
+    { name: 'Drain between chunks', opcode: 0x0D, sendFlag: 0x00, drainBetween: true },
+    { name: 'Flag $80 + drain (MESA protocol)', opcode: 0x0D, sendFlag: 0x80, drainBetween: true },
+    { name: 'Opcode 0x0B (SDATA) + flag $80 + drain', opcode: 0x0B, sendFlag: 0x80, drainBetween: true },
+  ];
+
+  for (const test of tests) {
+    const ok = await runTest(test, 0, samples);
+    if (ok) {
+      console.log(`  ✓ ALL CHUNKS SUCCEEDED`);
+    }
+  }
+
+  console.log('\n=== Done ===');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/modules/e2e-infra/src/node/lib/test-aspack-throughput.ts
+++ b/modules/e2e-infra/src/node/lib/test-aspack-throughput.ts
@@ -1,0 +1,161 @@
+/**
+ * Measure ASPACK multi-chunk throughput with different chunk sizes.
+ *
+ * Now that multi-chunk works (poll flag 0x00, not 0x80), measure
+ * throughput across chunk sizes to find the optimal configuration.
+ *
+ * Run: E2E_SCSI_BRIDGE_URL=http://10.0.0.57:7033 tsx modules/e2e-infra/src/node/lib/test-aspack-throughput.ts
+ */
+
+const BRIDGE_URL = process.env.E2E_SCSI_BRIDGE_URL ?? 'http://10.0.0.57:7033';
+const TARGET_ID = 6;
+const TOTAL_SAMPLES = 44100; // 1 second at 44.1kHz
+
+async function scsiExec(cdb: number[], dataOut: number[] = [], expectedIn = 0): Promise<number[]> {
+  const resp = await fetch(`${BRIDGE_URL}/scsi/exec`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target_id: TARGET_ID, cdb, data_out: dataOut, expected_data_in: expectedIn }),
+  });
+  if (!resp.ok) throw new Error(`scsi/exec HTTP ${resp.status}: ${await resp.text()}`);
+  return ((await resp.json()) as { data_in: number[] }).data_in ?? [];
+}
+
+async function midiEnable(): Promise<void> { await scsiExec([0x09, 0x00, 0x01, 0x00, 0x00, 0x00]); }
+async function midiDisable(): Promise<void> { await scsiExec([0x09, 0x00, 0x00, 0x00, 0x00, 0x00]); }
+
+async function midiSend(data: number[]): Promise<void> {
+  const len = data.length;
+  await scsiExec([0x0C, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], data, 0);
+}
+
+async function midiPoll(): Promise<number> {
+  const d = await scsiExec([0x0D, 0x00, 0x00, 0x00, 0x00, 0x00], [], 3);
+  if (d.length >= 3) return (d[0] << 16) | (d[1] << 8) | d[2];
+  return 0;
+}
+
+async function midiRead(len: number): Promise<number[]> {
+  return scsiExec([0x0E, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], [], len);
+}
+
+async function pollForReply(): Promise<number[]> {
+  for (let i = 0; i < 20; i++) {
+    const pending = await midiPoll();
+    if (pending > 0) return midiRead(pending);
+  }
+  return [];
+}
+
+function toNibbles(value: number, byteCount: number): number[] {
+  const nibbles: number[] = [];
+  for (let i = 0; i < byteCount; i++) {
+    const byte = (value >> (i * 8)) & 0xFF;
+    nibbles.push(byte & 0x0F, (byte >> 4) & 0x0F);
+  }
+  return nibbles;
+}
+
+function sampleToNibbles(sample: number): number[] {
+  const raw = sample & 0xFFFF;
+  return [raw & 0x0F, (raw >> 4) & 0x0F, (raw >> 8) & 0x0F, (raw >> 12) & 0x0F];
+}
+
+function buildASPACK(sampleIdx: number, offset: number, samples: Int16Array, start: number, count: number): number[] {
+  const msg = [0xF0, 0x47, 0x00, 0x0D, 0x48,
+    ...toNibbles(sampleIdx, 2),
+    ...toNibbles(offset, 4),
+    ...toNibbles(count, 4),
+  ];
+  for (let i = 0; i < count; i++) {
+    const s = start + i < samples.length ? samples[start + i] : 0;
+    msg.push(...sampleToNibbles(s));
+  }
+  msg.push(0xF7);
+  return msg;
+}
+
+async function testChunkSize(chunkSize: number, sampleIdx: number, samples: Int16Array): Promise<void> {
+  const chunks = Math.ceil(TOTAL_SAMPLES / chunkSize);
+  const totalBytes = TOTAL_SAMPLES * 2;
+
+  console.log(`\n--- Chunk: ${chunkSize} samples (${chunkSize * 2} bytes PCM), ${chunks} chunks ---`);
+
+  await midiEnable();
+
+  let offset = 0;
+  let failed = false;
+  const t0 = performance.now();
+
+  for (let i = 0; i < chunks; i++) {
+    const count = Math.min(chunkSize, TOTAL_SAMPLES - offset);
+    const msg = buildASPACK(sampleIdx, offset, samples, offset, count);
+
+    await midiSend(msg);
+    const reply = await pollForReply();
+
+    if (reply.length >= 4 && reply[3] === 0x16) {
+      // OK
+    } else {
+      console.log(`  FAILED at chunk ${i + 1}, offset=${offset}`);
+      failed = true;
+      break;
+    }
+    offset += count;
+  }
+
+  const totalMs = performance.now() - t0;
+  await midiDisable();
+
+  if (!failed) {
+    const throughput = totalBytes / (totalMs / 1000);
+    const perChunkMs = totalMs / chunks;
+    console.log(`  Total: ${Math.round(totalMs)}ms`);
+    console.log(`  Per-chunk: ${perChunkMs.toFixed(1)}ms`);
+    console.log(`  Throughput: ${(throughput / 1024).toFixed(1)} KB/s`);
+  }
+}
+
+async function main() {
+  console.log('=== ASPACK Multi-Chunk Throughput Test ===');
+  console.log(`Sample: ${TOTAL_SAMPLES} samples (${(TOTAL_SAMPLES * 2 / 1024).toFixed(1)} KB)\n`);
+
+  const samples = new Int16Array(TOTAL_SAMPLES);
+  for (let i = 0; i < TOTAL_SAMPLES; i++) {
+    samples[i] = Math.round(Math.sin(2 * Math.PI * 440 * i / 44100) * 16000);
+  }
+
+  // Verify samples on device
+  const listResp = await fetch(`${BRIDGE_URL}/sds/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: [0xF0, 0x47, 0x00, 0x04, 0x48, 0xF7] }),
+  });
+  const listJson = await listResp.json() as { response?: number[] };
+  const sampleCount = listJson.response && listJson.response.length > 6
+    ? Math.floor((listJson.response.length - 6) / 24) : 0;
+  if (sampleCount === 0) {
+    console.error('No samples on device.');
+    return;
+  }
+  // Use the last sample (most likely to have enough allocated memory)
+  const sampleIdx = sampleCount - 1;
+  console.log(`Samples on device: ${sampleCount}. Writing to index ${sampleIdx}.`);
+
+  for (const chunkSize of [192, 384, 768, 1536, 3072, 6144]) {
+    await testChunkSize(chunkSize, sampleIdx, samples);
+  }
+
+  // Also test single-chunk (entire sample at once)
+  await testChunkSize(TOTAL_SAMPLES, sampleIdx, samples);
+
+  console.log('\n\n=== Comparison ===');
+  console.log('Batched SDS:     2.2 KB/s');
+  console.log('See results above for ASPACK multi-chunk throughput');
+  console.log('\n=== Done ===');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/modules/e2e-infra/src/node/lib/test-sample-creation.ts
+++ b/modules/e2e-infra/src/node/lib/test-sample-creation.ts
@@ -1,0 +1,195 @@
+/**
+ * Test sample creation mechanisms — find the minimum action needed
+ * to register a new sample in RSLIST.
+ *
+ * Tests:
+ * 1. SDS dump header only (no data packets)
+ * 2. SDS dump header + 1 data packet
+ * 3. SDS dump header + ASPACK data (hybrid)
+ * 4. SDATA header write to new index
+ *
+ * Run: E2E_SCSI_BRIDGE_URL=http://10.0.0.57:7033 tsx modules/e2e-infra/src/node/lib/test-sample-creation.ts
+ */
+
+const BRIDGE_URL = process.env.E2E_SCSI_BRIDGE_URL ?? 'http://10.0.0.57:7033';
+const TARGET_ID = 6;
+
+async function scsiExec(cdb: number[], dataOut: number[] = [], expectedIn = 0): Promise<number[]> {
+  const resp = await fetch(`${BRIDGE_URL}/scsi/exec`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ target_id: TARGET_ID, cdb, data_out: dataOut, expected_data_in: expectedIn }),
+  });
+  if (!resp.ok) throw new Error(`scsi/exec HTTP ${resp.status}: ${await resp.text()}`);
+  return ((await resp.json()) as { data_in: number[] }).data_in ?? [];
+}
+
+async function midiEnable(): Promise<void> { await scsiExec([0x09, 0x00, 0x01, 0x00, 0x00, 0x00]); }
+async function midiDisable(): Promise<void> { await scsiExec([0x09, 0x00, 0x00, 0x00, 0x00, 0x00]); }
+
+async function midiSend(data: number[]): Promise<void> {
+  const len = data.length;
+  await scsiExec([0x0C, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], data, 0);
+}
+
+async function midiPoll(): Promise<number> {
+  const d = await scsiExec([0x0D, 0x00, 0x00, 0x00, 0x00, 0x00], [], 3);
+  if (d.length >= 3) return (d[0] << 16) | (d[1] << 8) | d[2];
+  return 0;
+}
+
+async function midiRead(len: number): Promise<number[]> {
+  return scsiExec([0x0E, 0x00, (len >> 16) & 0xFF, (len >> 8) & 0xFF, len & 0xFF, 0x00], [], len);
+}
+
+async function pollForReply(maxAttempts = 20): Promise<number[]> {
+  for (let i = 0; i < maxAttempts; i++) {
+    const pending = await midiPoll();
+    if (pending > 0) return midiRead(pending);
+  }
+  return [];
+}
+
+async function getSampleCount(): Promise<number> {
+  const resp = await fetch(`${BRIDGE_URL}/sds/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: [0xF0, 0x47, 0x00, 0x04, 0x48, 0xF7] }),
+  });
+  const json = await resp.json() as { response?: number[] };
+  const data = json.response ?? [];
+  if (data.length < 6) return 0;
+  return Math.floor((data.length - 6) / 24);
+}
+
+function buildDumpHeader(sampleNumber: number, sampleRate: number, totalSamples: number): number[] {
+  const snLo = sampleNumber & 0x7F;
+  const snHi = (sampleNumber >> 7) & 0x7F;
+  const p = Math.floor(1_000_000_000 / sampleRate);
+  return [
+    0xF0, 0x7E, 0x00, 0x01, snLo, snHi, 16,
+    p & 0x7F, (p >> 7) & 0x7F, (p >> 14) & 0x7F,
+    totalSamples & 0x7F, (totalSamples >> 7) & 0x7F, (totalSamples >> 14) & 0x7F,
+    0, 0, 0, 0, 0, 0, 0, 0xF7,
+  ];
+}
+
+function buildSdsDataPacket(pktNum: number): number[] {
+  const data = [0xF0, 0x7E, 0x00, 0x02, pktNum & 0x7F];
+  let checksum = 0x7E ^ 0x00 ^ 0x02 ^ (pktNum & 0x7F);
+  // 40 samples of silence (120 bytes)
+  for (let i = 0; i < 120; i++) {
+    data.push(0);
+    checksum ^= 0;
+  }
+  data.push(checksum & 0x7F, 0xF7);
+  return data;
+}
+
+async function main() {
+  console.log('=== Sample Creation Test ===\n');
+
+  const countBefore = await getSampleCount();
+  console.log(`Samples before: ${countBefore}\n`);
+
+  // Test 1: SDS dump header only
+  console.log('--- Test 1: SDS dump header only (no data packets) ---');
+  await midiEnable();
+  const header1 = buildDumpHeader(countBefore, 44100, 1000);
+  await midiSend(header1);
+  // Read WAIT + ACK
+  const ack1 = await pollForReply();
+  console.log(`  Header ACK: [${ack1.slice(0, 12).map(b => b.toString(16).padStart(2, '0')).join(' ')}]`);
+  // Don't send any data packets — just disable
+  await midiDisable();
+
+  const countAfter1 = await getSampleCount();
+  console.log(`  Samples after: ${countAfter1} (${countAfter1 > countBefore ? '✓ NEW SAMPLE' : '✗ no change'})\n`);
+
+  // Test 2: SDS dump header + 1 data packet
+  console.log('--- Test 2: SDS dump header + 1 data packet ---');
+  const countBefore2 = await getSampleCount();
+  await midiEnable();
+  const header2 = buildDumpHeader(countBefore2, 44100, 40); // exactly 1 packet worth
+  await midiSend(header2);
+  const ack2 = await pollForReply();
+  console.log(`  Header ACK: [${ack2.slice(0, 12).map(b => b.toString(16).padStart(2, '0')).join(' ')}]`);
+
+  // Send 1 data packet
+  const pkt = buildSdsDataPacket(0);
+  await midiSend(pkt);
+  const pktAck = await pollForReply();
+  console.log(`  Packet ACK: [${pktAck.slice(0, 6).map(b => b.toString(16).padStart(2, '0')).join(' ')}]`);
+  await midiDisable();
+
+  // Wait a moment for device to commit
+  await new Promise(r => setTimeout(r, 500));
+  const countAfter2 = await getSampleCount();
+  console.log(`  Samples after: ${countAfter2} (${countAfter2 > countBefore2 ? '✓ NEW SAMPLE' : '✗ no change'})\n`);
+
+  // Test 3: SDS dump header + ASPACK (hybrid — header creates slot, ASPACK fills data)
+  console.log('--- Test 3: SDS dump header + cancel + ASPACK ---');
+  const countBefore3 = await getSampleCount();
+  await midiEnable();
+  const header3 = buildDumpHeader(countBefore3, 44100, 1000);
+  await midiSend(header3);
+  const ack3 = await pollForReply();
+  console.log(`  Header ACK: [${ack3.slice(0, 12).map(b => b.toString(16).padStart(2, '0')).join(' ')}]`);
+
+  // Send SDS Cancel to end the SDS session
+  const cancel = [0xF0, 0x7E, 0x00, 0x7D, 0x00, 0xF7];
+  await midiSend(cancel);
+  await new Promise(r => setTimeout(r, 200));
+  // Drain any response
+  const pending = await midiPoll();
+  if (pending > 0) await midiRead(pending);
+
+  await midiDisable();
+  await new Promise(r => setTimeout(r, 500));
+  const countAfter3 = await getSampleCount();
+  console.log(`  Samples after cancel: ${countAfter3} (${countAfter3 > countBefore3 ? '✓ NEW SAMPLE' : '✗ no change'})\n`);
+
+  // Test 4: SDATA header write to new index
+  console.log('--- Test 4: SDATA header write to new index ---');
+  const countBefore4 = await getSampleCount();
+  // Build a minimal sample header via SDATA (opcode 0x0B)
+  // Need to write SLNGTH field with the desired sample count
+  // First, read an existing sample header to use as template
+  const templateResp = await fetch(`${BRIDGE_URL}/sds/send`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ message: [0xF0, 0x47, 0x00, 0x0A, 0x48, countBefore4 - 1, 0x00, 0xF7] }),
+  });
+  const templateJson = await templateResp.json() as { response?: number[] };
+  const templateData = templateJson.response ?? [];
+
+  if (templateData.length > 20) {
+    // Try writing this header data to a new index
+    // Change the opcode from 0x0B (response) to write, targeting new index
+    const writeMsg = [0xF0, 0x47, 0x00, 0x0B, 0x48, ...templateData.slice(5, -1), 0xF7];
+    // Replace the sample number nibbles at the start with the new index
+    // Actually, SDATA write might auto-target based on the index in the header
+    console.log(`  Template header: ${templateData.length} bytes`);
+
+    const writeResp = await fetch(`${BRIDGE_URL}/sds/send`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: writeMsg }),
+    });
+    const writeJson = await writeResp.json() as { response?: number[] };
+    const writeResult = writeJson.response ?? [];
+    console.log(`  SDATA write response: [${writeResult.slice(0, 10).map(b => b.toString(16).padStart(2, '0')).join(' ')}]`);
+
+    const countAfter4 = await getSampleCount();
+    console.log(`  Samples after: ${countAfter4} (${countAfter4 > countBefore4 ? '✓ NEW SAMPLE' : '✗ no change'})`);
+  } else {
+    console.log('  Could not read template header');
+  }
+
+  console.log('\n=== Done ===');
+}
+
+main().catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/modules/midi-core/src/transports/scsi-midi-transport.ts
+++ b/modules/midi-core/src/transports/scsi-midi-transport.ts
@@ -279,19 +279,26 @@ function createScsiSdsChannel(
 
       return new Promise<void>((resolve, reject) => {
         const sdsWs = new WebSocket(wsUrl);
-        // ASPACK timeout: ~20 KB/s throughput + margin. Minimum 30s.
-        const dataBytes = samples.length * 2;
-        const timeoutMs = Math.max(30_000, (dataBytes / 15) + 15_000);
-        const timeout = setTimeout(() => {
+
+        // Stall-based timeout: resets on every progress message.
+        // Fires only if no progress arrives for 30s (transfer genuinely stuck).
+        const STALL_MS = 30_000;
+        let stallTimer = setTimeout(onStall, STALL_MS);
+
+        function resetStallTimer(): void {
+          clearTimeout(stallTimer);
+          stallTimer = setTimeout(onStall, STALL_MS);
+        }
+
+        function onStall(): void {
           sdsWs.close();
-          reject(new Error(`Sample upload timed out after ${Math.round(timeoutMs / 1000)}s`));
-        }, timeoutMs);
+          reject(new Error('Sample upload stalled — no progress for 30s'));
+        }
 
         const totalPackets = Math.ceil(samples.length / 120);
 
         sdsWs.addEventListener('open', () => {
           // Use ASPACK fast path (8x faster than SDS).
-          // Falls back to SDS on bridges that don't support it.
           sdsWs.send(JSON.stringify({
             type: 'sample-upload-fast',
             target_id: DEFAULT_SCSI_TARGET_ID,
@@ -307,6 +314,7 @@ function createScsiSdsChannel(
 
           switch (msg.type) {
             case 'upload-progress':
+              resetStallTimer();
               if (onProgress) {
                 onProgress({
                   packetsSent: msg.transferred ?? 0,
@@ -318,13 +326,13 @@ function createScsiSdsChannel(
               break;
 
             case 'upload-complete':
-              clearTimeout(timeout);
+              clearTimeout(stallTimer);
               sdsWs.close();
               resolve();
               break;
 
             case 'sample-error':
-              clearTimeout(timeout);
+              clearTimeout(stallTimer);
               sdsWs.close();
               reject(new Error(`SDS upload error: ${msg.error}`));
               break;
@@ -332,7 +340,7 @@ function createScsiSdsChannel(
         });
 
         sdsWs.addEventListener('error', (event) => {
-          clearTimeout(timeout);
+          clearTimeout(stallTimer);
           reject(new Error(`SDS upload WebSocket error: ${event}`));
         });
       });

--- a/modules/midi-core/src/transports/scsi-midi-transport.ts
+++ b/modules/midi-core/src/transports/scsi-midi-transport.ts
@@ -279,20 +279,21 @@ function createScsiSdsChannel(
 
       return new Promise<void>((resolve, reject) => {
         const sdsWs = new WebSocket(wsUrl);
-        // Timeout scales with sample count: ~350ms per 40-sample packet + margin.
-        // Minimum 60s for small samples, no cap for large ones.
-        const packets = Math.ceil(samples.length / 40);
-        const timeoutMs = Math.max(60_000, packets * 400 + 30_000);
+        // ASPACK timeout: ~20 KB/s throughput + margin. Minimum 30s.
+        const dataBytes = samples.length * 2;
+        const timeoutMs = Math.max(30_000, (dataBytes / 15) + 15_000);
         const timeout = setTimeout(() => {
           sdsWs.close();
-          reject(new Error(`SDS upload timed out after ${Math.round(timeoutMs / 1000)}s`));
+          reject(new Error(`Sample upload timed out after ${Math.round(timeoutMs / 1000)}s`));
         }, timeoutMs);
 
         const totalPackets = Math.ceil(samples.length / 120);
 
         sdsWs.addEventListener('open', () => {
+          // Use ASPACK fast path (8x faster than SDS).
+          // Falls back to SDS on bridges that don't support it.
           sdsWs.send(JSON.stringify({
-            type: 'sample-upload',
+            type: 'sample-upload-fast',
             target_id: DEFAULT_SCSI_TARGET_ID,
             sample_number: sampleNumber,
             channel,

--- a/services/scsi-midi-bridge/src/routes.rs
+++ b/services/scsi-midi-bridge/src/routes.rs
@@ -450,24 +450,8 @@ async fn handle_ws_sample_upload(
         let total = samples.len() as u32;
         info!(target_id, sample_number, total, sample_rate, "starting sample upload task");
 
-        // Progress channel: worker pushes upload-progress messages here
         let (progress_tx, mut progress_rx) = mpsc::channel::<serde_json::Value>(128);
-        let tx_forward = tx.clone();
-        let tx_done = tx.clone();
 
-        let forward_handle = tokio::spawn(async move {
-            while let Some(msg) = progress_rx.recv().await {
-                // If the WebSocket is closed, stop forwarding. This drops
-                // progress_rx, causing the worker's try_send to fail and
-                // triggering the cancellation flag.
-                if tx_forward.send(msg).await.is_err() {
-                    info!("WebSocket closed — stopping SDS upload progress forwarding");
-                    break;
-                }
-            }
-        });
-
-        // Submit upload work item
         let (reply_tx, reply_rx) = oneshot::channel();
         let send_result = scsi_tx.send(ScsiWork::SdsUpload {
             target_id,
@@ -480,24 +464,48 @@ async fn handle_ws_sample_upload(
         }).await;
 
         if send_result.is_err() {
-            let _ = tx_done.send(serde_json::json!({"type": "sample-error", "error": "SCSI worker not running"})).await;
+            let _ = tx.send(serde_json::json!({"type": "sample-error", "error": "SCSI worker not running"})).await;
             return;
         }
 
-        // Timeout scales with sample count: ~200ms per 40-sample packet + margin.
-        // Minimum 60s, no upper cap — large samples can take many minutes.
-        let packets = (total as u64 + 39) / 40;
-        let timeout_secs = (packets / 4).max(60);
-        info!(total, packets, timeout_secs, "SDS upload timeout");
+        // Stall detection: timeout resets on every progress message.
+        // SDS is slower (~200ms/packet) but packets are frequent.
+        let stall_timeout = Duration::from_secs(30);
+        let stall_deadline = tokio::time::sleep(stall_timeout);
+        tokio::pin!(stall_deadline);
 
-        let result = match tokio::time::timeout(Duration::from_secs(timeout_secs), reply_rx).await {
-            Ok(Ok(r)) => r,
-            Ok(Err(_)) => Err("worker channel closed".to_string()),
-            Err(_) => Err("upload timed out (120s)".to_string()),
+        let mut stalled = false;
+
+        loop {
+            tokio::select! {
+                msg = progress_rx.recv() => {
+                    match msg {
+                        Some(progress_msg) => {
+                            stall_deadline.as_mut().reset(tokio::time::Instant::now() + stall_timeout);
+                            if tx.send(progress_msg).await.is_err() {
+                                info!("WebSocket closed during SDS upload");
+                                break;
+                            }
+                        }
+                        None => break, // Worker done, reply coming
+                    }
+                }
+                _ = &mut stall_deadline => {
+                    stalled = true;
+                    break;
+                }
+            }
+        }
+
+        let result = if stalled {
+            Err("SDS upload stalled — no progress for 30s".to_string())
+        } else {
+            match tokio::time::timeout(Duration::from_secs(5), reply_rx).await {
+                Ok(Ok(r)) => r,
+                Ok(Err(_)) => Err("worker channel closed".to_string()),
+                Err(_) => Err("worker did not send reply after completing".to_string()),
+            }
         };
-
-        // Wait for all progress messages to be forwarded
-        let _ = forward_handle.await;
 
         match result {
             Ok(total) => {
@@ -505,14 +513,14 @@ async fn handle_ws_sample_upload(
                     "type": "upload-complete",
                     "totalSamples": total,
                 });
-                let _ = tx_done.send(msg).await;
+                let _ = tx.send(msg).await;
             }
             Err(e) => {
                 let msg = serde_json::json!({
                     "type": "sample-error",
                     "error": e,
                 });
-                let _ = tx_done.send(msg).await;
+                let _ = tx.send(msg).await;
             }
         }
     });
@@ -549,17 +557,6 @@ async fn handle_ws_sample_upload_fast(
         info!(target_id, sample_number, total, sample_rate, "starting ASPACK upload task");
 
         let (progress_tx, mut progress_rx) = mpsc::channel::<serde_json::Value>(128);
-        let tx_forward = tx.clone();
-        let tx_done = tx.clone();
-
-        let forward_handle = tokio::spawn(async move {
-            while let Some(msg) = progress_rx.recv().await {
-                if tx_forward.send(msg).await.is_err() {
-                    info!("WebSocket closed — stopping ASPACK upload progress forwarding");
-                    break;
-                }
-            }
-        });
 
         let (reply_tx, reply_rx) = oneshot::channel();
         let send_result = scsi_tx.send(ScsiWork::AspackUpload {
@@ -573,22 +570,48 @@ async fn handle_ws_sample_upload_fast(
         }).await;
 
         if send_result.is_err() {
-            let _ = tx_done.send(serde_json::json!({"type": "sample-error", "error": "SCSI worker not running"})).await;
+            let _ = tx.send(serde_json::json!({"type": "sample-error", "error": "SCSI worker not running"})).await;
             return;
         }
 
-        // ASPACK is much faster — timeout based on ~25 KB/s throughput + margin
-        let data_bytes = total as u64 * 2;
-        let timeout_secs = (data_bytes / 20_000).max(30);
-        info!(total, timeout_secs, "ASPACK upload timeout");
+        // Stall detection: timeout resets on every progress message.
+        // Transfers of any size succeed as long as chunks keep arriving.
+        let stall_timeout = Duration::from_secs(30);
+        let stall_deadline = tokio::time::sleep(stall_timeout);
+        tokio::pin!(stall_deadline);
 
-        let result = match tokio::time::timeout(Duration::from_secs(timeout_secs), reply_rx).await {
-            Ok(Ok(r)) => r,
-            Ok(Err(_)) => Err("worker channel closed".to_string()),
-            Err(_) => Err(format!("ASPACK upload timed out after {timeout_secs}s")),
+        let mut stalled = false;
+
+        loop {
+            tokio::select! {
+                msg = progress_rx.recv() => {
+                    match msg {
+                        Some(progress_msg) => {
+                            stall_deadline.as_mut().reset(tokio::time::Instant::now() + stall_timeout);
+                            if tx.send(progress_msg).await.is_err() {
+                                info!("WebSocket closed during ASPACK upload");
+                                break;
+                            }
+                        }
+                        None => break, // Worker done, reply coming
+                    }
+                }
+                _ = &mut stall_deadline => {
+                    stalled = true;
+                    break;
+                }
+            }
+        }
+
+        let result = if stalled {
+            Err("ASPACK upload stalled — no progress for 30s".to_string())
+        } else {
+            match tokio::time::timeout(Duration::from_secs(5), reply_rx).await {
+                Ok(Ok(r)) => r,
+                Ok(Err(_)) => Err("worker channel closed".to_string()),
+                Err(_) => Err("worker did not send reply after completing".to_string()),
+            }
         };
-
-        let _ = forward_handle.await;
 
         match result {
             Ok(total) => {
@@ -596,14 +619,14 @@ async fn handle_ws_sample_upload_fast(
                     "type": "upload-complete",
                     "totalSamples": total,
                 });
-                let _ = tx_done.send(msg).await;
+                let _ = tx.send(msg).await;
             }
             Err(e) => {
                 let msg = serde_json::json!({
                     "type": "sample-error",
                     "error": e,
                 });
-                let _ = tx_done.send(msg).await;
+                let _ = tx.send(msg).await;
             }
         }
     });

--- a/services/scsi-midi-bridge/src/routes.rs
+++ b/services/scsi-midi-bridge/src/routes.rs
@@ -289,6 +289,11 @@ async fn handle_ws(
                                         &state, &parsed, dl_tx.clone(),
                                     ).await;
                                 }
+                                "sample-upload-fast" => {
+                                    handle_ws_sample_upload_fast(
+                                        &state, &parsed, dl_tx.clone(),
+                                    ).await;
+                                }
                                 _ => {}
                             }
                         }
@@ -492,6 +497,97 @@ async fn handle_ws_sample_upload(
         };
 
         // Wait for all progress messages to be forwarded
+        let _ = forward_handle.await;
+
+        match result {
+            Ok(total) => {
+                let msg = serde_json::json!({
+                    "type": "upload-complete",
+                    "totalSamples": total,
+                });
+                let _ = tx_done.send(msg).await;
+            }
+            Err(e) => {
+                let msg = serde_json::json!({
+                    "type": "sample-error",
+                    "error": e,
+                });
+                let _ = tx_done.send(msg).await;
+            }
+        }
+    });
+}
+
+/// Handle a "sample-upload-fast" WebSocket message.
+/// Uses ASPACK (Akai proprietary) for ~10x faster upload than SDS.
+/// Creates sample slot via minimal SDS, writes data via ASPACK chunks.
+async fn handle_ws_sample_upload_fast(
+    state: &Arc<AppState>,
+    parsed: &serde_json::Value,
+    tx: mpsc::Sender<serde_json::Value>,
+) {
+    let target_id = parsed["target_id"].as_u64().unwrap_or(6) as u8;
+    let sample_number = parsed["sample_number"].as_u64().unwrap_or(0) as u16;
+    let channel = parsed["channel"].as_u64().unwrap_or(0) as u8;
+    let sample_rate = parsed["sample_rate"].as_u64().unwrap_or(44100) as u32;
+
+    let samples: Vec<i16> = parsed["samples"]
+        .as_array()
+        .map(|arr| arr.iter().filter_map(|v| v.as_i64().map(|n| n as i16)).collect())
+        .unwrap_or_default();
+
+    if samples.is_empty() {
+        let msg = serde_json::json!({"type": "sample-error", "error": "no samples provided"});
+        let _ = tx.send(msg).await;
+        return;
+    }
+
+    let scsi_tx = state.scsi_tx.clone();
+
+    tokio::spawn(async move {
+        let total = samples.len() as u32;
+        info!(target_id, sample_number, total, sample_rate, "starting ASPACK upload task");
+
+        let (progress_tx, mut progress_rx) = mpsc::channel::<serde_json::Value>(128);
+        let tx_forward = tx.clone();
+        let tx_done = tx.clone();
+
+        let forward_handle = tokio::spawn(async move {
+            while let Some(msg) = progress_rx.recv().await {
+                if tx_forward.send(msg).await.is_err() {
+                    info!("WebSocket closed — stopping ASPACK upload progress forwarding");
+                    break;
+                }
+            }
+        });
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let send_result = scsi_tx.send(ScsiWork::AspackUpload {
+            target_id,
+            sample_number,
+            channel,
+            sample_rate,
+            samples,
+            progress: progress_tx,
+            reply: reply_tx,
+        }).await;
+
+        if send_result.is_err() {
+            let _ = tx_done.send(serde_json::json!({"type": "sample-error", "error": "SCSI worker not running"})).await;
+            return;
+        }
+
+        // ASPACK is much faster — timeout based on ~25 KB/s throughput + margin
+        let data_bytes = total as u64 * 2;
+        let timeout_secs = (data_bytes / 20_000).max(30);
+        info!(total, timeout_secs, "ASPACK upload timeout");
+
+        let result = match tokio::time::timeout(Duration::from_secs(timeout_secs), reply_rx).await {
+            Ok(Ok(r)) => r,
+            Ok(Err(_)) => Err("worker channel closed".to_string()),
+            Err(_) => Err(format!("ASPACK upload timed out after {timeout_secs}s")),
+        };
+
         let _ = forward_handle.await;
 
         match result {

--- a/services/scsi-midi-bridge/src/scsi_midi.rs
+++ b/services/scsi-midi-bridge/src/scsi_midi.rs
@@ -371,6 +371,218 @@ where
     Ok(total)
 }
 
+// =========================================================================
+// ASPACK fast upload (10x faster than SDS)
+// =========================================================================
+
+/// Upload a sample using ASPACK (Akai proprietary protocol).
+///
+/// Algorithm:
+/// 1. Create sample slot via minimal SDS (dump header + 1 silence packet)
+/// 2. Write real PCM data via ASPACK chunks (avoids block boundaries)
+/// 3. Progress reported per chunk
+///
+/// Throughput: ~16-23 KB/s vs ~2.2 KB/s for batched SDS.
+pub async fn upload_sample_aspack<F>(
+    s2p: &S2pClient,
+    target_id: u8,
+    sample_number: u16,
+    channel: u8,
+    sample_rate: u32,
+    samples: &[i16],
+    mut on_progress: F,
+    cancelled: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> Result<u32, String>
+where
+    F: FnMut(u32, u32),
+{
+    let total = samples.len() as u32;
+    if sample_rate == 0 {
+        return Err("sample_rate must be > 0".to_string());
+    }
+
+    info!(target_id, sample_number, total, sample_rate, "starting ASPACK upload");
+
+    s2p.scsi_midi_enable(target_id).await?;
+    let result = upload_sample_aspack_inner(
+        s2p, target_id, sample_number, channel, sample_rate, samples, &mut on_progress, cancelled,
+    ).await;
+    let _ = s2p.scsi_midi_disable(target_id).await;
+    result
+}
+
+async fn upload_sample_aspack_inner<F>(
+    s2p: &S2pClient,
+    target_id: u8,
+    sample_number: u16,
+    channel: u8,
+    sample_rate: u32,
+    samples: &[i16],
+    on_progress: &mut F,
+    cancelled: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) -> Result<u32, String>
+where
+    F: FnMut(u32, u32),
+{
+    let total = samples.len() as u32;
+
+    // Phase 1: Create sample slot via minimal SDS (dump header + 1 data packet)
+    info!("ASPACK phase 1: creating sample slot via minimal SDS");
+    let period_ns = 1_000_000_000u32 / sample_rate;
+    let sn_lo = (sample_number & 0x7F) as u8;
+    let sn_hi = ((sample_number >> 7) & 0x7F) as u8;
+
+    // Declare 40 samples (1 packet's worth) — we'll overwrite with ASPACK
+    let dump_header = vec![
+        0xF0, 0x7E, channel, 0x01,
+        sn_lo, sn_hi, 16,
+        (period_ns & 0x7F) as u8,
+        ((period_ns >> 7) & 0x7F) as u8,
+        ((period_ns >> 14) & 0x7F) as u8,
+        40u8 & 0x7F, 0, 0,             // length = 40 samples
+        0, 0, 0, 0, 0, 0, 0,           // loop start/end/type = 0
+        0xF7,
+    ];
+
+    s2p.scsi_midi_send(target_id, &dump_header).await?;
+    wait_for_ack(s2p, target_id, 30).await
+        .map_err(|e| format!("no ACK for dump header: {e}"))?;
+
+    // Send 1 data packet of silence to register the sample
+    let silence_pkt = encode_sds_data_packet(channel, 0, &[0i16; 40], 0, 40);
+    s2p.scsi_midi_send(target_id, &silence_pkt).await?;
+    wait_for_ack(s2p, target_id, 30).await
+        .map_err(|e| format!("no ACK for silence packet: {e}"))?;
+
+    info!("ASPACK phase 1 complete: sample slot created");
+
+    // Brief pause for device to commit
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    // Phase 2: Write real PCM data via ASPACK chunks
+    // Use chunk size 8191 to avoid Akai block boundaries (N×8192 rejected).
+    // Max single chunk is ~67000 samples (262 KB SysEx).
+    let chunk_size = if total <= 60000 { total as usize } else { 8191usize };
+    let mut offset = 0usize;
+
+    info!(total, chunk_size, "ASPACK phase 2: writing PCM data");
+
+    // Find the RSLIST index of the newly created sample.
+    // Query via raw CDBs (send RSLIST request, poll, read response).
+    let rslist_msg = vec![0xF0, 0x47, channel, 0x04, 0x48, 0xF7];
+    s2p.scsi_midi_send(target_id, &rslist_msg).await?;
+
+    // Poll for response
+    let mut rslist_resp = Vec::new();
+    for _ in 0..30 {
+        let pending = s2p.scsi_midi_poll(target_id).await?;
+        if pending > 0 {
+            rslist_resp = s2p.scsi_midi_read(target_id, pending).await?;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+
+    let sample_count = if rslist_resp.len() > 6 { (rslist_resp.len() - 6) / 24 } else { 0 };
+    let rslist_index = if sample_count > 0 { sample_count - 1 } else {
+        return Err("sample not found in RSLIST after SDS creation".to_string());
+    };
+
+    info!(rslist_index, sample_count, "found sample in RSLIST");
+
+    while offset < samples.len() {
+        if cancelled.load(std::sync::atomic::Ordering::Relaxed) {
+            info!("ASPACK upload cancelled");
+            return Err("upload cancelled".to_string());
+        }
+
+        let count = std::cmp::min(chunk_size, samples.len() - offset);
+
+        // Build ASPACK message: F0 47 cc 0D 48 [idx 4n] [offset 8n] [count 8n] [data 4n*count] F7
+        let mut msg = Vec::with_capacity(5 + 4 + 8 + 8 + count * 4 + 1);
+        msg.push(0xF0);
+        msg.push(0x47);
+        msg.push(channel);
+        msg.push(0x0D); // ASPACK opcode
+        msg.push(0x48); // S3000XL device ID
+
+        // Sample index (nibble-encoded, 2 bytes = 4 nibbles)
+        let idx = rslist_index as u16;
+        msg.push((idx & 0x0F) as u8);
+        msg.push(((idx >> 4) & 0x0F) as u8);
+        msg.push(((idx >> 8) & 0x0F) as u8);
+        msg.push(((idx >> 12) & 0x0F) as u8);
+
+        // Offset (nibble-encoded, 4 bytes = 8 nibbles)
+        let off = offset as u32;
+        for i in 0..4 {
+            let byte = ((off >> (i * 8)) & 0xFF) as u8;
+            msg.push(byte & 0x0F);
+            msg.push((byte >> 4) & 0x0F);
+        }
+
+        // Count (nibble-encoded, 4 bytes = 8 nibbles)
+        let cnt = count as u32;
+        for i in 0..4 {
+            let byte = ((cnt >> (i * 8)) & 0xFF) as u8;
+            msg.push(byte & 0x0F);
+            msg.push((byte >> 4) & 0x0F);
+        }
+
+        // PCM data (nibble-encoded, 4 nibbles per 16-bit sample)
+        for i in 0..count {
+            let s = if offset + i < samples.len() { samples[offset + i] as u16 } else { 0u16 };
+            msg.push((s & 0x0F) as u8);
+            msg.push(((s >> 4) & 0x0F) as u8);
+            msg.push(((s >> 8) & 0x0F) as u8);
+            msg.push(((s >> 12) & 0x0F) as u8);
+        }
+
+        msg.push(0xF7);
+
+        let t0 = std::time::Instant::now();
+        s2p.scsi_midi_send(target_id, &msg).await?;
+
+        // Poll for REPLY (flag 0x00 required)
+        let mut got_reply = false;
+        for _ in 0..30 {
+            let pending = s2p.scsi_midi_poll(target_id).await?;
+            if pending > 0 {
+                let reply = s2p.scsi_midi_read(target_id, pending).await?;
+                if reply.len() >= 4 && reply[3] == 0x16 {
+                    got_reply = true;
+                    break;
+                }
+            }
+        }
+
+        if !got_reply {
+            return Err(format!("no REPLY for ASPACK chunk at offset {offset}"));
+        }
+
+        let chunk_ms = t0.elapsed().as_millis() as u64;
+        offset += count;
+        let sent = (offset as u32).min(total);
+        on_progress(sent, total);
+
+        if offset <= chunk_size || offset % (chunk_size * 5) < chunk_size {
+            info!(
+                offset,
+                chunk_ms,
+                progress = format!("{}/{}", sent, total),
+                "ASPACK chunk"
+            );
+        }
+    }
+
+    info!(total, "ASPACK upload complete");
+    Ok(total)
+}
+
+// =========================================================================
+// SDS encoding helpers
+// =========================================================================
+
 /// Encode a 16-bit PCM sample into 3 SDS bytes (7-bit encoding, MSB first).
 fn encode_sds_sample(sample: i16) -> [u8; 3] {
     let raw = sample as u16;

--- a/services/scsi-midi-bridge/src/worker.rs
+++ b/services/scsi-midi-bridge/src/worker.rs
@@ -47,6 +47,16 @@ pub enum ScsiWork {
         progress: mpsc::Sender<serde_json::Value>,
         reply: oneshot::Sender<Result<u32, String>>,
     },
+    /// ASPACK fast sample upload via scsi_midi::upload_sample_aspack
+    AspackUpload {
+        target_id: u8,
+        sample_number: u16,
+        channel: u8,
+        sample_rate: u32,
+        samples: Vec<i16>,
+        progress: mpsc::Sender<serde_json::Value>,
+        reply: oneshot::Sender<Result<u32, String>>,
+    },
     /// SDS sample download via scsi_midi::download_sample
     SdsDownload {
         target_id: u8,
@@ -123,6 +133,25 @@ pub async fn scsi_worker(
                         });
                         // If the progress receiver is gone (WebSocket disconnected),
                         // signal cancellation so upload_sample stops sending packets.
+                        if progress.try_send(msg).is_err() {
+                            cancelled_clone.store(true, std::sync::atomic::Ordering::Relaxed);
+                        }
+                    },
+                    &cancelled,
+                ).await;
+                let _ = reply.send(result);
+            }
+            ScsiWork::AspackUpload { target_id, sample_number, channel, sample_rate, samples, progress, reply } => {
+                let cancelled = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+                let cancelled_clone = cancelled.clone();
+                let result = scsi_midi::upload_sample_aspack(
+                    &s2p, target_id, sample_number, channel, sample_rate, &samples,
+                    |sent, total| {
+                        let msg = serde_json::json!({
+                            "type": "upload-progress",
+                            "transferred": sent,
+                            "total": total,
+                        });
                         if progress.try_send(msg).is_err() {
                             cancelled_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                         }


### PR DESCRIPTION
## Summary

- **ASPACK protocol integration**: Reverse-engineered Akai's proprietary ASPACK bulk write protocol for the S3000XL. Solved multi-chunk writes (poll flag 0x00, not 0x80), sample creation (minimal SDS: 1 dump header + 1 data packet), and block boundary avoidance (chunk size 8191).
- **Bridge + web editor end-to-end**: New `sample-upload-fast` WebSocket endpoint in the bridge creates a sample slot via SDS, queries RSLIST for the index, then writes PCM data via ASPACK chunks. Web editor uses this path automatically.
- **Stall-based timeouts**: Replaced fixed overall timeout with per-progress-message stall detection (30s deadline resets on every chunk). Works for any sample size.
- **Bug fixes**: Ghost SendSampleDialog (effect dep on `deviceSampleCount`), device memory scroll cap (`max-h-48`), IPv6 proxy, drop event propagation, progress label.

### Throughput

| Method | Speed | Relative |
|--------|-------|----------|
| SDS (unbatched) | 0.25 KB/s | 1x |
| SDS (batched 20) | 2.2 KB/s | 9x |
| ASPACK (multi-chunk) | 17.2 KB/s | 69x |
| ASPACK (single chunk) | 23.4 KB/s | 94x |

## Test plan

- [x] Upload small sample (<60K) via web editor — uses single-chunk ASPACK
- [x] Upload large sample (573K) via web editor — uses multi-chunk ASPACK with 8191-sample chunks
- [x] Verify stall timeout does not fire during normal transfer
- [x] Verify ghost dialog no longer appears after successful transfer
- [x] Verify device memory panel uses full available height
- [ ] Upload from disk browser drag-drop to device
- [ ] Upload via ImportInstrumentDialog (program with missing samples)