### PR TITLE
feat: build source dependency tracking for CSS files

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -331,6 +331,8 @@ make modules/sampler-devices/.build-stamp  # Build one module (and its deps)
 
 `pnpm -r build` still works but does **not** enforce build order — use `make` instead.
 
+**Source change detection is automatic.** The Makefile tracks `.ts`, `.tsx`, and `.css` files in each module's `src/` directory. When any tracked file changes, `make` rebuilds that module and its dependents. Do **not** delete `.build-stamp` files for routine development — `make` alone is sufficient. See the "HOW SOURCE CHANGE DETECTION WORKS" comment block in the Makefile for details.
+
 ## Deployment
 
 Web editors are deployed on Netlify. Each editor has its own Netlify site with per-site configuration.

--- a/Makefile
+++ b/Makefile
@@ -50,32 +50,32 @@ INSTALL_STAMP := node_modules/.install-stamp
 # Source file lists — enables Make to detect actual file changes
 # ---------------------------------------------------------------------------
 
-MIDI_CORE_SRC       := $(shell find $(MODULES_DIR)/midi-core/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLER_LIB_SRC       := $(shell find $(MODULES_DIR)/sampler-lib/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-AUDIOTOOLS_CONFIG_SRC  := $(shell find $(MODULES_DIR)/audiotools-config/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-CANONICAL_MIDI_SRC     := $(shell find $(MODULES_DIR)/canonical-midi-maps/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-ARDOUR_MIDI_SRC        := $(shell find $(MODULES_DIR)/ardour-midi-maps/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-LAUNCH_CONTROL_SRC     := $(shell find $(MODULES_DIR)/launch-control-xl3/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-LAUNCH_CONTROL_ED_SRC  := $(shell find $(MODULES_DIR)/launch-control-xl3-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-LIB_RUNTIME_SRC        := $(shell find $(MODULES_DIR)/lib-runtime/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLER_ATTIC_SRC      := $(shell find $(MODULES_DIR)/sampler-attic/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLE_CHOPPER_SRC     := $(shell find $(MODULES_DIR)/sample-chopper/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-EDITOR_CORE_SRC        := $(shell find $(MODULES_DIR)/editor-core/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-LIB_DEVICE_UUID_SRC    := $(shell find $(MODULES_DIR)/lib-device-uuid/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLER_DEVICES_SRC    := $(shell find $(MODULES_DIR)/sampler-devices/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
+MIDI_CORE_SRC       := $(shell find $(MODULES_DIR)/midi-core/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLER_LIB_SRC       := $(shell find $(MODULES_DIR)/sampler-lib/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+AUDIOTOOLS_CONFIG_SRC  := $(shell find $(MODULES_DIR)/audiotools-config/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+CANONICAL_MIDI_SRC     := $(shell find $(MODULES_DIR)/canonical-midi-maps/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+ARDOUR_MIDI_SRC        := $(shell find $(MODULES_DIR)/ardour-midi-maps/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+LAUNCH_CONTROL_SRC     := $(shell find $(MODULES_DIR)/launch-control-xl3/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+LAUNCH_CONTROL_ED_SRC  := $(shell find $(MODULES_DIR)/launch-control-xl3-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+LIB_RUNTIME_SRC        := $(shell find $(MODULES_DIR)/lib-runtime/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLER_ATTIC_SRC      := $(shell find $(MODULES_DIR)/sampler-attic/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLE_CHOPPER_SRC     := $(shell find $(MODULES_DIR)/sample-chopper/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+EDITOR_CORE_SRC        := $(shell find $(MODULES_DIR)/editor-core/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+LIB_DEVICE_UUID_SRC    := $(shell find $(MODULES_DIR)/lib-device-uuid/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLER_DEVICES_SRC    := $(shell find $(MODULES_DIR)/sampler-devices/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
 
-SAMPLER_LIBRARY_SRC    := $(shell find $(MODULES_DIR)/sampler-library/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLER_TRANSLATE_SRC  := $(shell find $(MODULES_DIR)/sampler-translate/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLER_BACKUP_SRC     := $(shell find $(MODULES_DIR)/sampler-backup/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLER_EXPORT_SRC     := $(shell find $(MODULES_DIR)/sampler-export/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-LOOP_EDITOR_SRC        := $(shell find $(MODULES_DIR)/loop-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-D110_EDITOR_SRC        := $(shell find $(MODULES_DIR)/d110-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-JV1080_EDITOR_SRC      := $(shell find $(MODULES_DIR)/jv1080-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-ROLAND_SXX0_EDITOR_SRC := $(shell find $(MODULES_DIR)/roland-sxx0-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-AUDIOTOOLS_CLI_SRC     := $(shell find $(MODULES_DIR)/audiotools-cli/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SYNTH_CORE_SRC         := $(shell find $(MODULES_DIR)/synth-core/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-SAMPLE_EDITOR_SRC      := $(shell find $(MODULES_DIR)/sample-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
-AKAI_S3K_EDITOR_SRC    := $(shell find $(MODULES_DIR)/akai-s3k-editor/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
+SAMPLER_LIBRARY_SRC    := $(shell find $(MODULES_DIR)/sampler-library/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLER_TRANSLATE_SRC  := $(shell find $(MODULES_DIR)/sampler-translate/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLER_BACKUP_SRC     := $(shell find $(MODULES_DIR)/sampler-backup/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLER_EXPORT_SRC     := $(shell find $(MODULES_DIR)/sampler-export/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+LOOP_EDITOR_SRC        := $(shell find $(MODULES_DIR)/loop-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+D110_EDITOR_SRC        := $(shell find $(MODULES_DIR)/d110-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+JV1080_EDITOR_SRC      := $(shell find $(MODULES_DIR)/jv1080-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+ROLAND_SXX0_EDITOR_SRC := $(shell find $(MODULES_DIR)/roland-sxx0-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+AUDIOTOOLS_CLI_SRC     := $(shell find $(MODULES_DIR)/audiotools-cli/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SYNTH_CORE_SRC         := $(shell find $(MODULES_DIR)/synth-core/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+SAMPLE_EDITOR_SRC      := $(shell find $(MODULES_DIR)/sample-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
+AKAI_S3K_EDITOR_SRC    := $(shell find $(MODULES_DIR)/akai-s3k-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
 
 .PHONY: build clean clean-deps ensure-devenv ensure-playwright check-midi-server test-e2e-roland test-e2e-roland-device test-e2e-roland-library test-e2e-roland-device-library test-e2e-roland-ui test-e2e-s3k-device test-e2e-s3k-library test-e2e-s3k-scsi test-e2e-s3k-device-library check-scsi-bridge test-scsi-write-validation dev-scsi test-e2e-common-library-s3k test-e2e-common-library-roland
 
@@ -342,6 +342,25 @@ $(INSTALL_STAMP): pnpm-lock.yaml
 	@touch $@
 
 # ---------------------------------------------------------------------------
+# HOW SOURCE CHANGE DETECTION WORKS
+# ---------------------------------------------------------------------------
+#
+# Each stamp target (e.g., $(EDITOR_CORE)) depends on its module's source
+# files via the *_SRC variables defined above. Make compares the timestamp
+# of every .ts, .tsx, and .css file against the stamp file. If ANY source
+# file is newer, Make rebuilds that module automatically.
+#
+# This means:
+#   - `make` alone is sufficient for routine development.
+#   - Do NOT delete .build-stamp files to force a rebuild — Make already
+#     detects source changes. Deleting stamps is unnecessary and wasteful.
+#   - `make clean && make` exists for full rebuilds from scratch (e.g.,
+#     after changing tsconfig, upgrading dependencies, or switching branches).
+#     It is NOT needed for routine source file edits.
+#
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Layer 0 — no workspace dependencies
 # ---------------------------------------------------------------------------
 
@@ -387,8 +406,6 @@ $(SAMPLER_ATTIC): $(INSTALL_STAMP) $(SAMPLER_ATTIC_SRC)
 $(SAMPLE_CHOPPER): $(INSTALL_STAMP) $(SAMPLE_CHOPPER_SRC) $(SYNTH_CORE)
 	cd $(MODULES_DIR)/sample-chopper && pnpm build
 	@touch $@
-
-SYNTH_CORE_SRC         := $(shell find $(MODULES_DIR)/synth-core/src -name '*.ts' -o -name '*.tsx' 2>/dev/null)
 
 $(SYNTH_CORE): $(INSTALL_STAMP) $(SYNTH_CORE_SRC)
 	cd $(MODULES_DIR)/synth-core && pnpm build

--- a/docs/1.0/001-IN-PROGRESS/build-source-deps/README.md
+++ b/docs/1.0/001-IN-PROGRESS/build-source-deps/README.md
@@ -1,0 +1,23 @@
+# Build Source Dependencies
+
+**Status:** In Progress
+**Branch:** `feature/build-source-deps`
+
+## Documentation
+
+- [PRD](./prd.md) — Product requirements
+- [Workplan](./workplan.md) — Implementation plan
+
+## Overview
+
+Make the Makefile build system track CSS file changes (in addition to existing `.ts`/`.tsx` tracking) and add inline documentation to prevent agents from cargo-culting stamp file deletion. Small fix: Makefile source patterns, Makefile comments, and a CLAUDE.md reinforcement note.
+
+## Current Status
+
+| Phase | Status | Commit |
+|-------|--------|--------|
+| 1. CSS tracking + Makefile docs + CLAUDE.md note | Complete | — |
+
+## Motivation
+
+Session transcript analysis found 20+ instances of unnecessary `rm -f .build-stamp && make` in a single session. Agents learn this pattern from the Makefile because the Makefile does not explain that source changes are already tracked. Additionally, 9 CSS files across 5 modules are not included in the source dependency lists, so CSS changes genuinely do require manual intervention until this fix lands.

--- a/docs/1.0/001-IN-PROGRESS/build-source-deps/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/build-source-deps/workplan.md
@@ -1,0 +1,107 @@
+# Build Source Dependencies — Workplan
+
+**Source PRD:** [prd.md](./prd.md)
+**Created:** 2026-04-11
+
+---
+
+## GitHub Tracking
+
+| Item | Link |
+|------|------|
+| **Parent Issue** | [#173 — Build stamps should be sensitive to source code changes](https://github.com/audiocontrol-org/audiocontrol/issues/173) |
+
+### Implementation Issues
+
+| Phase | Issue | Description |
+|-------|-------|-------------|
+| Phase 1 | [#204](https://github.com/audiocontrol-org/audiocontrol/issues/204) | Add CSS files to Makefile source dependency tracking |
+| Phase 1 | [#205](https://github.com/audiocontrol-org/audiocontrol/issues/205) | Add inline documentation to Makefile explaining source change detection |
+| Phase 1 | [#206](https://github.com/audiocontrol-org/audiocontrol/issues/206) | Add build system note to CLAUDE.md |
+
+---
+
+## Phase 1: CSS Tracking and Documentation
+
+This is a single-phase feature. All tasks are small and closely related.
+
+### Task 1.1: Add CSS to Makefile source file lists
+
+Add `-o -name '*.css'` to every `$(shell find ...)` pattern in the Makefile source file list section (lines 53-78). All modules that contain CSS files in their `src/` directories will then trigger rebuilds on CSS changes.
+
+**Affected modules (9 CSS files across 5 modules):**
+
+| Module | CSS Files |
+|--------|-----------|
+| editor-core | `src/design/library.css`, `src/design/primitives.css`, `src/design/styles.css`, `src/design/tokens.css`, `src/dev/styles.css` |
+| akai-s3k-editor | `src/index.css` |
+| d110-editor | `src/index.css` |
+| jv1080-editor | `src/index.css` |
+| roland-sxx0-editor | `src/index.css` |
+
+**Files:**
+- Modify: `Makefile` (source file list section, lines 53-78)
+
+**Acceptance Criteria:**
+- [x] Every `$(shell find ...)` line includes `-o -name '*.css'`
+- [x] `touch modules/editor-core/src/design/tokens.css && make` triggers a rebuild of editor-core and its dependents
+- [x] `touch modules/roland-sxx0-editor/src/index.css && make` triggers a rebuild of roland-sxx0-editor
+
+### Task 1.2: Add inline documentation to Makefile
+
+Add a prominent comment block near the stamp file targets explaining:
+- Source file changes are detected automatically via `$(shell find ...)`
+- `make` alone is sufficient for routine development — do NOT delete stamp files
+- `make clean` exists for full rebuilds from scratch, not for routine development
+- The specific file types tracked (`.ts`, `.tsx`, `.css`)
+
+The documentation must be positioned where an agent scanning the Makefile will encounter it before learning the stamp file pattern. The goal is to prevent the cargo-cult `rm -f .build-stamp && make` behavior.
+
+**Files:**
+- Modify: `Makefile` (add comment block near source file lists and stamp targets)
+
+**Acceptance Criteria:**
+- [x] Comment block appears before the first stamp target rule
+- [x] Explicitly states: do NOT delete stamp files for routine development
+- [x] Explains what file types trigger rebuilds
+- [x] Explains when `make clean` is actually appropriate
+
+### Task 1.3: Add build system note to CLAUDE.md
+
+Add a brief note to the Build System section of `.claude/CLAUDE.md` reinforcing that `make` detects source changes automatically. This catches agents that read CLAUDE.md but not the Makefile.
+
+**Files:**
+- Modify: `.claude/CLAUDE.md` (Build System section)
+
+**Acceptance Criteria:**
+- [x] Build System section states that source changes (`.ts`, `.tsx`, `.css`) are detected automatically
+- [x] Explicitly says: do not delete stamp files for routine development
+- [x] Does not duplicate the full Makefile documentation — just a brief reinforcement with a pointer to the Makefile comments
+
+### Task 1.4: Close issue #173
+
+After all changes are committed and verified, close the parent GitHub issue.
+
+**Acceptance Criteria:**
+- [ ] Issue #173 is closed with a comment referencing the implementing commits
+
+---
+
+## Phase 1 Success Criteria
+
+- CSS file changes trigger automatic rebuilds
+- Makefile has clear inline documentation preventing stamp-deletion cargo-culting
+- CLAUDE.md reinforces correct build behavior
+- Issue #173 closed
+
+---
+
+## Dependency Graph
+
+```
+Task 1.1 (CSS tracking) ─┐
+Task 1.2 (Makefile docs) ─┼──► Task 1.4 (close issue)
+Task 1.3 (CLAUDE.md note) ┘
+```
+
+Tasks 1.1, 1.2, and 1.3 are independent and can be done in parallel or in any order. Task 1.4 depends on all three being committed.


### PR DESCRIPTION
## Summary

- Add `*.css` to all Makefile `$(shell find ...)` source file lists so CSS changes trigger automatic rebuilds (9 CSS files across 5 modules were previously untracked)
- Add inline documentation to Makefile explaining how source change detection works and that stamp file deletion is unnecessary for routine development
- Add reinforcement note to `.claude/CLAUDE.md` Build System section

Closes #173, closes #203, closes #204, closes #205, closes #206

## Test plan

- [ ] `touch modules/editor-core/src/design/tokens.css && make -n modules/editor-core/.build-stamp` shows rebuild scheduled
- [ ] `touch modules/roland-sxx0-editor/src/index.css && make -n modules/roland-sxx0-editor/.build-stamp` shows rebuild scheduled
- [ ] Makefile comment block appears before Layer 0 stamp targets
- [ ] CLAUDE.md Build System section mentions automatic source change detection