### PR TITLE
docs: add Codex guidelines and repo-local skills

### DIFF
--- a/.agents/skills/analyze-session/SKILL.md
+++ b/.agents/skills/analyze-session/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: analyze-session
+description: Run the session extraction and analysis pipeline, then summarize the resulting trends and improvement signals.
+---
+
+# Analyze Session
+
+Use this when the user wants the full session-analysis pipeline run.
+
+## Workflow
+
+1. Extract metrics: `tsx tools/extract-sessions.ts`
+2. Extract session content if needed: `tsx tools/extract-session-content.ts`
+3. Run the LLM analysis step if credentials and environment are available.
+4. Generate the report: `tsx tools/analyze-sessions.ts`
+5. Stage the produced `data/sessions/` updates if the user wants them committed.
+6. Report:
+   - main arc distribution
+   - top correction categories
+   - sessions with the most corrections
+   - useful improvement suggestions

--- a/.agents/skills/deploy-bridge/SKILL.md
+++ b/.agents/skills/deploy-bridge/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: deploy-bridge
+description: Build, deploy, and verify the SCSI MIDI bridge on the target Pi, then report the resulting status.
+---
+
+# Deploy Bridge
+
+Use this when the user explicitly wants bridge deployment.
+
+## Workflow
+
+1. Run `make deploy-scsi-bridge`.
+2. Verify the deploy result and confirm bridge health.
+3. If needed, inspect:
+   - `curl http://s3k.local:7033/status`
+   - `ssh orion@s3k.local 'tail -20 /tmp/e2e-bridge.log'`
+4. Report whether deployment succeeded and what still needs attention.

--- a/.agents/skills/feature-complete/SKILL.md
+++ b/.agents/skills/feature-complete/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: feature-complete
+description: Mark a merged feature complete by moving docs, updating roadmap state, and closing tracking issues.
+---
+
+# Feature Complete
+
+Use this after the feature PR is merged.
+
+## Workflow
+
+1. Confirm the feature is merged.
+2. Move docs from `docs/1.0/001-IN-PROGRESS/<slug>` to the complete area.
+3. Update `ROADMAP.md` if the feature is represented there.
+4. Update the feature `README.md` status.
+5. Close remaining tracking issues.
+6. Report moved paths, issue closures, and any newly unblocked features.
+
+This is post-merge bookkeeping, not implementation.

--- a/.agents/skills/feature-define/SKILL.md
+++ b/.agents/skills/feature-define/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: feature-define
+description: Interview the user to define a feature, then write a single feature definition file that downstream setup steps can consume.
+---
+
+# Feature Define
+
+Use this when a feature is not yet structured.
+
+## Goals
+
+- clarify the problem
+- define success criteria
+- set scope boundaries
+- outline a practical implementation breakdown
+
+## Workflow
+
+1. Gather:
+   - problem statement
+   - proposed slug
+   - acceptance criteria
+   - out-of-scope items
+2. Propose a technical approach:
+   - affected modules
+   - dependencies
+   - open questions
+3. Propose implementation phases and task groupings.
+4. Write `/tmp/feature-definition-<slug>.md`.
+5. Tell the user the next step is `feature-setup`.
+
+Keep the interview lean. Reuse answers the user already gave instead of re-asking them.

--- a/.agents/skills/feature-help/SKILL.md
+++ b/.agents/skills/feature-help/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: feature-help
+description: Explain the audiocontrol feature lifecycle and report the current state of active, in-progress, or partially defined features.
+---
+
+# Feature Help
+
+Use this when the user wants process guidance rather than implementation.
+
+## Lifecycle
+
+`feature-define -> feature-setup -> feature-issues -> feature-implement -> feature-review -> feature-ship -> feature-complete -> feature-teardown`
+
+Supporting skills:
+
+- `session-start`
+- `session-end`
+- `feature-pickup`
+
+## State Check
+
+Report:
+
+1. active worktree and branch
+2. in-progress features under `docs/1.0/001-IN-PROGRESS/`
+3. pending `/tmp/feature-definition-*.md` files not yet consumed
+4. the likely next step for each feature
+
+This skill is informational only. Do not start modifying files.

--- a/.agents/skills/feature-implement/SKILL.md
+++ b/.agents/skills/feature-implement/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: feature-implement
+description: "Drive the core implementation loop for a feature: pick the next workplan task, implement it, verify it, and update progress."
+---
+
+# Feature Implement
+
+Use this when the user wants the next planned task executed.
+
+## Workflow
+
+1. Identify the feature and read the next incomplete item in `workplan.md`.
+2. Read the relevant source files, interfaces, and tests before editing.
+3. Implement the smallest change that satisfies the task and acceptance criteria.
+4. Run the relevant tests.
+5. Update `workplan.md` if the task is now complete.
+6. Report what changed, how it was verified, and what remains.
+
+## Codex Delegation Rule
+
+If the user explicitly asks for sub-agents or parallel work, Codex may use:
+
+- `explorer` for narrow read-only research
+- `worker` for bounded implementation with an explicit file ownership scope
+
+Otherwise perform the work locally.

--- a/.agents/skills/feature-issues/SKILL.md
+++ b/.agents/skills/feature-issues/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: feature-issues
+description: Create GitHub tracking issues from a completed workplan and backfill the workplan with the resulting issue links.
+---
+
+# Feature Issues
+
+Use this when feature docs exist and issue tracking needs to be created.
+
+## Workflow
+
+1. Identify the feature and read:
+   - `docs/1.0/001-IN-PROGRESS/<slug>/prd.md`
+   - `docs/1.0/001-IN-PROGRESS/<slug>/workplan.md`
+2. Create one parent feature issue.
+3. Create child implementation issues per phase or major task group.
+4. Update the workplan with a `GitHub Tracking` section containing the created issue links.
+5. Report all created issues and the next likely step.
+
+Use GitHub URLs, not local file paths, in issue bodies.

--- a/.agents/skills/feature-pickup/SKILL.md
+++ b/.agents/skills/feature-pickup/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: feature-pickup
+description: Rehydrate context for an in-progress feature by reading the workplan, notes, and issue state, then propose the next implementation move.
+---
+
+# Feature Pickup
+
+Use this when a feature worktree already exists and the user wants to resume.
+
+## Workflow
+
+1. Identify the feature from the current worktree and branch.
+2. Read `workplan.md`, `README.md`, and the latest relevant `DEVELOPMENT-NOTES.md` entry.
+3. Check issue state if the workplan references GitHub issues.
+4. Report:
+   - progress percentage
+   - current phase
+   - next incomplete task
+   - open issues
+   - likely next implementation move
+
+Do not begin coding until the user confirms or redirects.

--- a/.agents/skills/feature-review/SKILL.md
+++ b/.agents/skills/feature-review/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: feature-review
+description: Review recent feature changes with a code-review mindset focused on correctness, regressions, risks, and missing tests.
+---
+
+# Feature Review
+
+Use this when the user asks for a review or pre-ship quality pass.
+
+## Workflow
+
+1. Determine the review scope from:
+   - uncommitted changes
+   - staged changes
+   - or branch diff vs `main`
+2. Read the relevant workplan context.
+3. Review for:
+   - correctness
+   - regressions
+   - missing tests
+   - guideline violations from `AGENTS.md`
+4. Report findings first, ordered by severity, with file and line references.
+
+This skill reports issues. It does not silently fix them unless the user asks.

--- a/.agents/skills/feature-setup/SKILL.md
+++ b/.agents/skills/feature-setup/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: feature-setup
+description: "Create feature infrastructure: branch, worktree, docs directory, and initial project documents derived from a feature definition."
+---
+
+# Feature Setup
+
+Use this when the user wants to create the project-management scaffolding for a new feature.
+
+## Workflow
+
+1. Determine the slug.
+2. Read `/tmp/feature-definition-<slug>.md` if it exists.
+3. Create the worktree and branch:
+   - `git worktree add ~/work/audiocontrol-work/audiocontrol-<slug> -b feature/<slug>`
+4. Create `docs/1.0/001-IN-PROGRESS/<slug>/`.
+5. Create:
+   - `prd.md`
+   - `workplan.md`
+   - `README.md`
+   - `implementation-summary.md`
+6. Populate those files from the definition if present; otherwise create minimal templates.
+7. Report the branch, worktree, docs path, and whether the docs were template-only or definition-backed.
+
+Do not start implementation as part of setup.

--- a/.agents/skills/feature-ship/SKILL.md
+++ b/.agents/skills/feature-ship/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: feature-ship
+description: Prepare a completed feature for merge by validating the workplan, running tests, and opening a pull request with a concise summary and test plan.
+---
+
+# Feature Ship
+
+Use this when implementation is done and the user wants the branch prepared for review.
+
+## Workflow
+
+1. Verify all acceptance criteria in `workplan.md`.
+2. Run the relevant tests for affected modules.
+3. Perform a final review pass.
+4. Ensure the branch is pushed.
+5. Create a PR with:
+   - concise summary
+   - test plan based on acceptance criteria
+6. Update the feature `README.md` to show PR-open state.
+7. Report the PR URL and any residual risks.
+
+Do not create a PR if critical tests are failing unless the user explicitly wants that.

--- a/.agents/skills/feature-teardown/SKILL.md
+++ b/.agents/skills/feature-teardown/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: feature-teardown
+description: Remove local feature infrastructure such as worktree and branch without making assumptions about feature status.
+---
+
+# Feature Teardown
+
+Use this when the user wants local cleanup only.
+
+## Workflow
+
+1. Identify the feature slug.
+2. Verify the worktree exists.
+3. Check for uncommitted changes.
+4. If the worktree is clean, remove it.
+5. Delete the local branch with safe deletion first.
+6. Prune stale worktree references.
+
+If uncommitted changes exist, stop and ask before removing anything.

--- a/.agents/skills/session-end/SKILL.md
+++ b/.agents/skills/session-end/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: session-end
+description: Wrap up a Codex work session by updating feature docs, recording development notes, and closing the loop on issue and hardware notes where needed.
+---
+
+# Session End
+
+Use this when the user wants a clean end-of-session wrap-up.
+
+## Workflow
+
+1. Update the active feature `README.md` status table.
+2. Update `workplan.md`:
+   - check off completed items
+   - add new tasks discovered
+   - record phase changes if any
+3. Add a `DEVELOPMENT-NOTES.md` entry with:
+   - goal
+   - what was accomplished
+   - what failed
+   - course corrections
+   - approximate quantitative notes if useful
+4. Update hardware notes if protocol or device behavior was investigated.
+5. Update or close related GitHub issues if the change materially advanced them.
+6. Commit the documentation updates with the code changes they describe.

--- a/.agents/skills/session-start/SKILL.md
+++ b/.agents/skills/session-start/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: session-start
+description: Bootstrap a Codex session by reading the active feature workplan, latest journal notes, and relevant issue context before implementation starts.
+---
+
+# Session Start
+
+Use this when the user wants the current feature state summarized before work begins.
+
+## Workflow
+
+1. Identify the feature from `pwd` and `git rev-parse --abbrev-ref HEAD`.
+2. Read:
+   - `docs/1.0/001-IN-PROGRESS/<feature>/README.md`
+   - `docs/1.0/001-IN-PROGRESS/<feature>/workplan.md`
+   - latest relevant entry in `DEVELOPMENT-NOTES.md`
+3. If the task is hardware-facing, read the latest relevant entries in `SCSI-NOTES.md` or the matching device notes file.
+4. If `data/sessions/report-all.md` exists, extract the top correction patterns that should influence this session.
+5. If issue state matters, inspect the relevant GitHub issues.
+6. Report:
+   - current phase
+   - completed vs pending work
+   - last session outcome
+   - likely risks
+   - proposed goal for this session
+
+Do not start coding until the user confirms or redirects.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,115 @@
+# audiocontrol Codex Guide
+
+This file is the Codex equivalent of the workspace-level `.claude/CLAUDE.md`. Keep both in sync while the repo supports both agents.
+
+## Scope
+
+TypeScript monorepo for MIDI device control, bridge services, and web-based editors. Primary tooling is `pnpm`, `tsx`, Vitest, and GitHub issue-driven feature work.
+
+## Session Start
+
+Before writing code:
+
+1. Identify the active feature from the worktree name, branch, or the user request.
+2. Read `docs/<version>/<feature-slug>/README.md` and `workplan.md`.
+3. Read the latest relevant entry in `DEVELOPMENT-NOTES.md`.
+4. If the work touches hardware or transport behavior, read the relevant notes file first, such as `SCSI-NOTES.md`.
+5. Check related GitHub issues when the task depends on issue state.
+6. Tell the user what you found and what you plan to do next.
+
+## Session End
+
+Before wrapping a feature session:
+
+1. Update the feature `README.md` status table.
+2. Update `workplan.md` with completed items and newly discovered work.
+3. Write a `DEVELOPMENT-NOTES.md` entry.
+4. Update hardware notes if device behavior was investigated.
+5. Update or close relevant GitHub issues.
+6. Commit documentation changes with the implementation changes they describe.
+
+## Feature Workflow
+
+Canonical flow:
+
+`PRD -> workplan.md -> GitHub issues -> implementation -> implementation-summary.md`
+
+Feature docs live under `docs/<version>/<feature-slug>/`.
+
+## Repo-Local Codex Skills
+
+Codex equivalents of the Claude skills live under `.agents/skills/`:
+
+- `session-start`
+- `session-end`
+- `feature-help`
+- `feature-define`
+- `feature-setup`
+- `feature-issues`
+- `feature-pickup`
+- `feature-implement`
+- `feature-review`
+- `feature-ship`
+- `feature-complete`
+- `feature-teardown`
+- `deploy-bridge`
+- `analyze-session`
+
+Prefer these skills when the user asks for that workflow explicitly.
+
+## Core Engineering Rules
+
+- Use `@/` imports for internal module paths when the module already follows that convention.
+- Do not add fallbacks or mock data outside test code. Throw explicit errors instead.
+- TypeScript strict mode is required.
+- Prefer interfaces and dependency injection across boundaries.
+- Use composition, not inheritance.
+- Avoid `any`; use `unknown` plus narrowing.
+- Keep files under roughly 300-500 lines. Refactor before they become gravity wells.
+- All public logic should be unit testable.
+- If a convention must be broken, document the deviation at the point of use.
+
+## Multi-Device UI Rule
+
+Do not branch UI components on device type or device capability. Device-specific behavior belongs behind factory-created interfaces, not inline conditionals in shared UI.
+
+## Nucleation Site Prevention
+
+Remove bad patterns instead of documenting around them:
+
+- duplicate logic
+- dead code
+- backward-compatibility shims
+- large files that mix unrelated responsibilities
+
+If future agents would be tempted to copy it, treat it as debt and fix or remove it.
+
+## Hardware and Protocol Work
+
+Do not speculate about device behavior. Test against real hardware or cite a primary source. Capture findings, timing, and evidence in the relevant docs.
+
+For bridge work:
+
+1. Edit `services/scsi-midi-bridge/src/`
+2. Deploy with `make deploy-scsi-bridge`
+3. Verify with `curl http://s3k.local:7033/status`
+4. Check logs if needed
+
+## Before Committing
+
+- Progress indicators show bytes, elapsed time, and ETA when applicable.
+- No hardcoded pixel layouts where proportional flex layouts are expected.
+- No defensive sleeps when protocol ACK or response semantics already define completion.
+- No fabricated claims about hardware behavior.
+- Error messages are actionable.
+- Feature docs are updated for the work performed.
+
+## Delegation in Codex
+
+Codex can use sub-agents only when the user explicitly asks for delegation, sub-agents, or parallel agent work. When that happens:
+
+- use `explorer` for narrow codebase questions
+- use `worker` for bounded implementation tasks with an explicit write scope
+- keep the critical-path task local when waiting would block progress
+
+Do not assume agent delegation is available by default.


### PR DESCRIPTION
## Summary

- add \ as the repo-local Codex guide mirroring the existing Claude-oriented project guidance
- add repo-local Codex skill definitions under \ for session, feature, deployment, and analysis workflows
- establish the baseline skill scaffolding so Codex can follow the same documented project-management flow as Claude Code

## Notes

- this PR contains only the Codex guidelines/skills port
- unrelated local edits and feature scaffolding were intentionally left out of the branch

## Testing

- not run; documentation and skill-definition files only