### PR TITLE
docs: align Codex and Claude repo guidance

### DIFF
--- a/.agents/skills/feature-extend/SKILL.md
+++ b/.agents/skills/feature-extend/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: feature-extend
+description: Extend a feature's scope mid-implementation by adding new phases to the existing docs and issue plan without creating a new branch or worktree.
+---
+
+# Feature Extend
+
+Use this when an in-progress feature needs additional scope that should stay on the same feature branch and worktree.
+
+Do not use this to start a new feature or to split work into a separate feature.
+
+## Workflow
+
+1. Identify the active feature from `pwd` and `git rev-parse --abbrev-ref HEAD`.
+2. Read:
+   - `docs/1.0/001-IN-PROGRESS/<feature>/prd.md`
+   - `docs/1.0/001-IN-PROGRESS/<feature>/workplan.md`
+   - `docs/1.0/001-IN-PROGRESS/<feature>/README.md`
+3. Check current GitHub issue state if the feature already tracks issues.
+4. Summarize the current phase layout, completed phases, remaining phases, and issue coverage.
+5. Capture the added scope:
+   - what new capability is needed
+   - why the existing scope is insufficient
+   - whether the change modifies an existing phase or adds a new one
+6. Propose the added phases or tasks before editing docs.
+7. After confirmation, update the existing docs:
+   - append to `prd.md` rather than rewriting earlier scope
+   - append new phases or tasks to `workplan.md` using the existing format
+   - update `README.md` if the phase table or summary needs to reflect the broader scope
+8. If GitHub tracking exists, create or plan the additional implementation issues and backfill the workplan links.
+9. Report the new phase count, changed scope, and next implementation step.
+
+Do not create a new worktree or branch as part of feature extension.

--- a/.agents/skills/feature-help/SKILL.md
+++ b/.agents/skills/feature-help/SKILL.md
@@ -9,13 +9,14 @@ Use this when the user wants process guidance rather than implementation.
 
 ## Lifecycle
 
-`feature-define -> feature-setup -> feature-issues -> feature-implement -> feature-review -> feature-ship -> feature-complete -> feature-teardown`
+`feature-define -> feature-setup -> feature-issues -> feature-implement -> feature-extend -> feature-review -> feature-ship -> feature-complete -> feature-teardown`
 
 Supporting skills:
 
 - `session-start`
 - `session-end`
 - `feature-pickup`
+- `feature-extend`
 
 ## State Check
 

--- a/.agents/skills/session-end/SKILL.md
+++ b/.agents/skills/session-end/SKILL.md
@@ -22,4 +22,5 @@ Use this when the user wants a clean end-of-session wrap-up.
    - approximate quantitative notes if useful
 4. Update hardware notes if protocol or device behavior was investigated.
 5. Update or close related GitHub issues if the change materially advanced them.
-6. Commit the documentation updates with the code changes they describe.
+6. If requested, run the session-analysis tooling and include the key metrics in the notes.
+7. Commit the documentation updates with the code changes they describe.

--- a/.agents/skills/session-start/SKILL.md
+++ b/.agents/skills/session-start/SKILL.md
@@ -13,14 +13,21 @@ Use this when the user wants the current feature state summarized before work be
 2. Read:
    - `docs/1.0/001-IN-PROGRESS/<feature>/README.md`
    - `docs/1.0/001-IN-PROGRESS/<feature>/workplan.md`
-   - latest relevant entry in `DEVELOPMENT-NOTES.md`
+   - the latest relevant entry in `DEVELOPMENT-NOTES.md`
 3. If the task is hardware-facing, read the latest relevant entries in `SCSI-NOTES.md` or the matching device notes file.
 4. If `data/sessions/report-all.md` exists, extract the top correction patterns that should influence this session.
 5. If issue state matters, inspect the relevant GitHub issues.
-6. Report:
-   - current phase
+6. If the feature involves UI work:
+   - read `TESTING.md`
+   - read `TESTING-UI.md`
+   - check whether the feature already has a harness page
+   - check whether UI specs already exist for the interactions being changed
+7. Report:
+   - feature name and current phase
    - completed vs pending work
    - last session outcome
+   - top correction patterns to avoid repeating
+   - top unresolved issues
    - likely risks
    - proposed goal for this session
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,6 +2,17 @@
 
 TypeScript monorepo for audio device control, MIDI communication, and web-based editors for vintage samplers and synthesizers. Uses pnpm workspaces with Vitest for testing.
 
+This file is the Claude equivalent of the workspace-level `AGENTS.md`. Keep both in sync while the repo supports both agents.
+
+## Canonical Sync Path
+
+Shared repo guidance must stay aligned between `AGENTS.md` and `.claude/CLAUDE.md`.
+
+- Start edits in whichever file is more natural for the current agent session
+- Before finishing, mirror the same substantive guidance into the counterpart file
+- Preserve only differences that are explicitly tied to real tool constraints
+- If a difference is intentional, say so at the point of divergence instead of letting it look accidental
+
 ## Session Lifecycle
 
 ### Starting a Session
@@ -63,6 +74,8 @@ Review changes against project standards:
 ## Sub-Agent Delegation
 
 Delegate to sub-agents proactively — don't wait for the user to ask. The main agent should orchestrate; sub-agents should do the work.
+
+This is an intentional difference from `AGENTS.md`, which restricts Codex sub-agent use to cases where the user explicitly asks for delegation, sub-agents, or parallel agent work.
 
 | Task Pattern | Agent | Why |
 |-------------|-------|-----|

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,15 @@
 
 This file is the Codex equivalent of the workspace-level `.claude/CLAUDE.md`. Keep both in sync while the repo supports both agents.
 
+## Canonical Sync Path
+
+Shared repo guidance must stay aligned between `AGENTS.md` and `.claude/CLAUDE.md`.
+
+- Start edits in whichever file is more natural for the current agent session.
+- Before finishing, mirror the same substantive guidance into the counterpart file.
+- Preserve only differences that are explicitly tied to real tool constraints.
+- If a difference is intentional, say so at the point of divergence instead of letting it look accidental.
+
 ## Scope
 
 TypeScript monorepo for MIDI device control, bridge services, and web-based editors. Primary tooling is `pnpm`, `tsx`, Vitest, and GitHub issue-driven feature work.
@@ -13,9 +22,10 @@ Before writing code:
 1. Identify the active feature from the worktree name, branch, or the user request.
 2. Read `docs/<version>/<feature-slug>/README.md` and `workplan.md`.
 3. Read the latest relevant entry in `DEVELOPMENT-NOTES.md`.
-4. If the work touches hardware or transport behavior, read the relevant notes file first, such as `SCSI-NOTES.md`.
-5. Check related GitHub issues when the task depends on issue state.
-6. Tell the user what you found and what you plan to do next.
+4. Check open or related GitHub issues when the task depends on issue state.
+5. If the work touches hardware or transport behavior, read the relevant notes file first, such as `SCSI-NOTES.md`.
+6. If the work touches UI behavior, read `TESTING.md` and `TESTING-UI.md`, then verify whether the feature already has a harness page and UI specs.
+7. Tell the user what you found and what you plan to do next.
 
 ## Session End
 
@@ -36,6 +46,26 @@ Canonical flow:
 
 Feature docs live under `docs/<version>/<feature-slug>/`.
 
+## Project Management
+
+Features follow the workflow in [PROJECT-MANAGEMENT.md](~/work/PROJECT-MANAGEMENT.md).
+
+**Feature docs:** `docs/<version>/<feature-slug>/` containing `prd.md`, `workplan.md`, and `README.md`
+
+**Roadmap:** `docs/1.0/ROADMAP.md` for dependency graph, feature states, and phase tracking
+
+**Worktrees:** `~/work/audiocontrol-work/audiocontrol-<feature-slug>/` on branch `feature/<feature-slug>`
+
+**Multi-machine:** Work happens on multiple machines. Session logs are machine-local and do not sync. Git branches do sync. Always rehydrate from `workplan.md` and the latest `DEVELOPMENT-NOTES.md` entry rather than assuming prior conversational context exists.
+
+### Start a New Feature
+
+1. Read `docs/1.0/ROADMAP.md` for prerequisites and dependencies.
+2. Create `docs/<version>/<feature-slug>/`.
+3. Write `prd.md`, `workplan.md`, and `README.md`.
+4. Create GitHub issues linked from the workplan.
+5. Create the worktree with `git worktree add ~/work/audiocontrol-work/audiocontrol-<slug> -b feature/<slug>`.
+
 ## Repo-Local Codex Skills
 
 Codex equivalents of the Claude skills live under `.agents/skills/`:
@@ -48,6 +78,7 @@ Codex equivalents of the Claude skills live under `.agents/skills/`:
 - `feature-issues`
 - `feature-pickup`
 - `feature-implement`
+- `feature-extend`
 - `feature-review`
 - `feature-ship`
 - `feature-complete`
@@ -102,7 +133,22 @@ For bridge work:
 - No defensive sleeps when protocol ACK or response semantics already define completion.
 - No fabricated claims about hardware behavior.
 - Error messages are actionable.
+- UI features are visually verified with the existing test harness process in `TESTING-UI.md`.
+- No ad-hoc test infrastructure is introduced when `modules/e2e-infra/` or existing `make test-*` targets already cover the need.
 - Feature docs are updated for the work performed.
+
+## Build and Test
+
+Use the root `Makefile` to build the monorepo in dependency order.
+
+```bash
+make
+make clean
+pnpm test
+pnpm --filter <module> test
+```
+
+Prefer `make` over `pnpm -r build` for full builds because the Make-based flow enforces module build order.
 
 ## Delegation in Codex
 
@@ -113,3 +159,40 @@ Codex can use sub-agents only when the user explicitly asks for delegation, sub-
 - keep the critical-path task local when waiting would block progress
 
 Do not assume agent delegation is available by default.
+
+This is an intentional difference from `.claude/CLAUDE.md`, which is allowed to assume proactive repo-local agent delegation.
+
+## Contract Enforcement
+
+The compiler must catch contract violations.
+
+- Do not use optional bags of callbacks where a shared contract should be mandatory.
+- Do not duplicate shared types to "get around" compile failures.
+- Do not hide unsupported behavior behind silent no-ops.
+- When shared interfaces change, update every consumer until the build fails nowhere.
+- When changing shared code in `editor-core`, build all affected editors before committing.
+
+## Repository Hygiene
+
+- Build artifacts belong in `dist/`.
+- Do not bypass pre-commit or pre-push hooks.
+- Do not commit temporary files, logs, or generated artifacts unless the repo explicitly tracks them.
+- Use `pnpm` for package operations.
+- Use `tsx` for running TypeScript scripts.
+
+## Monorepo Conventions
+
+- Each module should have clear boundaries and self-contained responsibilities.
+- Shared types belong in dedicated packages.
+- Internal dependencies should use the `workspace:*` protocol where applicable.
+
+## URL Convention for Editors
+
+Editors are served at `https://audiocontrol.org/<manufacturer>/<device>/editor`.
+
+## Documentation Standards
+
+- Do not call unfinished work "production-ready".
+- Do not express project-management goals in temporal promises when milestone or phase language is more accurate.
+- Do not invent projection statistics.
+- Use GitHub links, not local file paths, in GitHub issue descriptions.

--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -1120,3 +1120,39 @@ Add CSS file tracking to Makefile source dependencies and add inline documentati
 ### Insights
 1. Well-scoped features with clear workplans and pre-created issues make sessions fast and frictionless
 2. Small features benefit from doing all tasks in a single commit rather than splitting artificially
+
+---
+
+## 2026-04-17: Codex and Claude Parity Baseline and Alignment
+
+### Feature: codex-claude-parity
+### Worktree: audiocontrol-codex-claude-parity
+
+### Goal
+Audit the current Codex and Claude repo-local guidance, close unintentional parity gaps, and leave behind explicit maintenance guidance so future changes do not drift silently.
+
+### Accomplished
+- Fetched and verified the worktree against `origin/main` before auditing; committed history matched exactly at the audit baseline
+- Added a feature-local parity audit artifact documenting shared guidance, matched skills, intentional divergences, and Claude-only tool-specific repo artifacts
+- Expanded `AGENTS.md` to match the shared substance in `.claude/CLAUDE.md`, including project-management, build/test, contract-enforcement, hygiene, and documentation guidance
+- Added an explicit canonical sync path to both `AGENTS.md` and `.claude/CLAUDE.md`
+- Added Codex `feature-extend` and aligned Codex `session-start`, `session-end`, and `feature-help` skills with the Claude workflow substance
+- Added a parity maintenance checklist documenting what must stay aligned and which Claude-only repo artifacts are intentionally tool-specific
+- Updated the feature README and workplan so all four parity phases are marked complete
+
+### Didn't Work
+- No code or tests were run during this session because the work stayed at the documentation and repo-local skill-definition layer
+
+### Course Corrections
+- [PROCESS] Verified `origin/main` explicitly before continuing the audit rather than assuming the local branch was current
+- [DOCUMENTATION] Normalized the parity audit after the alignment work so it reflects the final state rather than the earlier audit snapshot
+
+### Quantitative
+- User messages: ~12
+- Commits: 1
+- User corrections: 1
+
+### Insights
+1. Parity work needs a canonical maintenance note or future audits will keep rediscovering the same "missing" artifacts.
+2. The important distinction is "matched in substance" versus "identical file-for-file"; tool-driven differences should be documented, not flattened.
+3. Verifying against `origin/main` before auditing prevents false positives when the repo surface may have changed upstream.

--- a/docs/1.0/001-IN-PROGRESS/codex-claude-parity/README.md
+++ b/docs/1.0/001-IN-PROGRESS/codex-claude-parity/README.md
@@ -1,0 +1,29 @@
+# Codex and Claude Parity
+
+**Status:** In Progress
+**Branch:** `feature/codex-claude-parity`
+
+## Documentation
+
+- [PRD](./prd.md) -- Product requirements
+- [Workplan](./workplan.md) -- Implementation plan
+- [Parity Audit](./parity-audit.md) -- Phase 1 inventory and gap baseline
+- [Parity Maintenance](./parity-maintenance.md) -- Drift-prevention checklist and intentional divergences
+- [Implementation Summary](./implementation-summary.md) -- Ship summary
+
+## Overview
+
+Ensure skill and directive parity between Codex and Claude Code in this repository so both agents can operate against the same workflows, project rules, and expected session behaviors without drift.
+
+## Current Status
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| 1. Audit | Complete | Baseline captured in `parity-audit.md` after comparing current branch to `origin/main` |
+| 2. Directive Alignment | Complete | `AGENTS.md` expanded to match shared Claude guidance; canonical sync path and intentional delegation difference are now explicit in both top-level guides |
+| 3. Skill and Workflow Parity | Complete | Added Codex `feature-extend` and aligned repo-local session lifecycle skills; remaining one-sided repo artifacts are now explicit rather than accidental |
+| 4. Verification and Drift Prevention | Complete | Audit normalized to final state and maintenance checklist added for future parity edits |
+
+## Motivation
+
+This repo already expects both Codex and Claude Code to follow the same project-management lifecycle, session behaviors, and engineering rules. If the two systems drift, agents will produce inconsistent setup, inconsistent close-out behavior, and inconsistent workflow coverage. The fix is to make parity explicit: inventory both sides, close accidental gaps, document intentional differences, and leave a maintainable parity artifact behind.

--- a/docs/1.0/001-IN-PROGRESS/codex-claude-parity/implementation-summary.md
+++ b/docs/1.0/001-IN-PROGRESS/codex-claude-parity/implementation-summary.md
@@ -1,0 +1,13 @@
+# Implementation Summary: codex-claude-parity
+
+## Overview
+[To be completed when feature ships]
+
+## Key Decisions
+[Canonical source choice, intentional divergences, and maintenance approach]
+
+## What Changed
+[Skills, directives, and parity artifacts added, removed, or aligned]
+
+## Lessons Learned
+[What caused drift, what prevented it, what should be maintained going forward]

--- a/docs/1.0/001-IN-PROGRESS/codex-claude-parity/parity-audit.md
+++ b/docs/1.0/001-IN-PROGRESS/codex-claude-parity/parity-audit.md
@@ -1,0 +1,96 @@
+# Codex and Claude Parity Audit Baseline
+
+**Date:** 2026-04-17
+**Feature Branch:** `feature/codex-claude-parity`
+**Baseline:** `HEAD` was compared to `origin/main` before this audit and had no committed drift (`0 0`). The only local delta was this feature's untracked docs directory.
+
+## Audit Scope
+
+Artifacts reviewed for this baseline:
+
+- `AGENTS.md`
+- `.claude/CLAUDE.md`
+- `.agents/skills/*/SKILL.md`
+- `.claude/skills/*/SKILL.md`
+- `.claude/agents/*.md`
+- `.claude/rules/*.md`
+- `.claude/workflows/*.yaml`
+- `.claude/project.yaml`
+
+## Inventory Summary
+
+| Surface | Codex | Claude | Classification |
+|--------|-------|--------|----------------|
+| Top-level repo guide | `AGENTS.md` | `.claude/CLAUDE.md` | Matched in substance |
+| Repo-local skills | 15 | 15 | Matched by count |
+| Repo-local agent personas | 0 | 13 | Missing on Codex |
+| Repo-local rules | 0 | 7 | Missing on Codex |
+| Repo-local workflow definitions | 0 | 3 | Missing on Codex |
+| Repo-local project config | 0 | 1 | Missing on Codex |
+
+## Directive Parity
+
+| Topic | Status | Notes |
+|------|--------|-------|
+| Session start flow | Matched in substance | Both guides now require feature identification, README/workplan review, DEVELOPMENT-NOTES review, issue checks when relevant, hardware-note review, and UI-testing checks when UI work is involved. |
+| Session end flow | Matched in substance | Both guides now require README/workplan updates, DEVELOPMENT-NOTES updates, hardware-note updates when relevant, issue updates, and support optional session analytics. |
+| Feature lifecycle | Matched | Both describe the same core flow: `PRD -> workplan.md -> GitHub issues -> implementation -> implementation-summary.md`. |
+| Core engineering rules | Matched in substance | Both align on `@/` imports, strict TypeScript, no fallbacks/mock data, DI/interfaces, composition, avoiding `any`, file-size discipline, unit testability, multi-device UI composition, hardware evidence, and anti-debt cleanup. |
+| Delegation policy | Intentional divergence | `AGENTS.md` restricts Codex sub-agent use to explicit user requests. `.claude/CLAUDE.md` instructs proactive delegation and ships repo-local orchestrator agents that require delegation. This is an explicit tool-model difference. |
+| Build and test guidance | Matched in substance | Both guides now state the Make-based build path, test expectations, UI verification expectations, and avoidance of ad-hoc test infrastructure. |
+| Project-management detail | Matched in substance | Both guides now cover roadmap/worktree naming, multi-machine context, and new-feature setup flow. |
+| Contract enforcement and repo hygiene | Matched in substance | Both guides now cover contract enforcement, repo hygiene, monorepo conventions, URL conventions, and documentation standards. |
+
+## Skill Inventory
+
+| Skill | Codex | Claude | Status | Notes |
+|------|-------|--------|--------|-------|
+| `session-start` | Yes | Yes | Matched in substance | Both now cover feature docs, notes, hardware context, issue state, session-analysis signals, and UI-testing checks when relevant. |
+| `session-end` | Yes | Yes | Matched in substance | Both now cover README/workplan updates, notes, hardware and issue updates, and optional session-analysis handling. |
+| `feature-help` | Yes | Yes | Matched in substance | Both now describe the same lifecycle shape, including `feature-extend` as a workflow step. |
+| `feature-define` | Yes | Yes | Matched | Same role: capture feature definition before setup. |
+| `feature-setup` | Yes | Yes | Partial | Same infrastructure goal. Claude version explicitly delegates doc creation to `documentation-engineer`; Codex version is tool-agnostic. |
+| `feature-issues` | Yes | Yes | Matched | Same role: create tracking issues and backfill workplan links. |
+| `feature-pickup` | Yes | Yes | Matched | Same role: rehydrate an in-progress feature from docs/issues. |
+| `feature-implement` | Yes | Yes | Matched | Same core implementation-loop intent. |
+| `feature-review` | Yes | Yes | Matched | Same review role. |
+| `feature-ship` | Yes | Yes | Matched | Same ship/PR-prep role. |
+| `feature-complete` | Yes | Yes | Matched | Same completion/closeout role. |
+| `feature-teardown` | Yes | Yes | Matched | Same infrastructure cleanup role. |
+| `deploy-bridge` | Yes | Yes | Matched | Same bridge deployment workflow exists on both sides. |
+| `analyze-session` | Yes | Yes | Matched | Same session-analysis workflow exists on both sides. |
+| `feature-extend` | Yes | Yes | Matched | Both now provide a repo-local workflow for broadening an in-progress feature without creating a new worktree. |
+
+## Claude-Only Repo Surfaces
+
+These artifacts currently have no repo-local Codex equivalent:
+
+- `.claude/agents/*.md`
+  Claude ships 13 task-specific agent personas, including `project-orchestrator`, `feature-orchestrator`, `documentation-engineer`, `hardware-protocol-engineer`, and `code-reviewer`.
+- `.claude/rules/*.md`
+  Claude ships separate rule docs for deployment, testing, UI development, session analytics, workflow playbooks, and device-specific guidance.
+- `.claude/workflows/*.yaml`
+  Claude ships workflow descriptors for general project work and feature development.
+- `.claude/project.yaml`
+  Claude has additional project metadata that points at workflows, skills, and feature infrastructure expectations.
+
+For parity purposes, these are now treated as tool-specific repo artifacts rather than accidental gaps. Some of their behavior is already covered by Codex platform instructions, and the repo does not currently need one-to-one local mirrors for them.
+
+## Current Conclusion
+
+What is clearly matched:
+
+- Top-level repo guidance in `AGENTS.md` and `.claude/CLAUDE.md`
+- Repo-local workflow skills by name and purpose
+- Core engineering constraints around typing, DI, UI composition, testing, and hardware evidence
+
+What is clearly not yet aligned:
+
+- Claude has additional repo-local rules, workflows, and agent persona docs that remain intentionally tool-specific
+- Some Claude skill files still contain more execution detail, even where the workflow intent now matches
+
+## Remaining Phase 4 Focus
+
+- Leave behind a concise maintenance checklist for future parity edits.
+- Record the intentional tool-specific artifacts so they are not re-audited as accidental drift.
+- Note any deferred one-to-one mirroring work explicitly rather than implying it is complete.

--- a/docs/1.0/001-IN-PROGRESS/codex-claude-parity/parity-maintenance.md
+++ b/docs/1.0/001-IN-PROGRESS/codex-claude-parity/parity-maintenance.md
@@ -1,0 +1,51 @@
+# Codex and Claude Parity Maintenance
+
+Use this checklist whenever shared agent guidance changes in this repo.
+
+## Canonical Rule
+
+If a change affects shared repo behavior, update both:
+
+- `AGENTS.md`
+- `.claude/CLAUDE.md`
+
+If the difference is intentional because of tool constraints, say so explicitly in both places or in the parity docs.
+
+## What Must Stay Aligned
+
+- Session start and session end expectations
+- Feature lifecycle terminology and ordering
+- Core engineering rules
+- Build and test guidance
+- Project-management and worktree conventions
+- Contract-enforcement and repository-hygiene rules
+- Repo-local skills under `.agents/skills/` and `.claude/skills/` when the workflow is meant to exist for both agents
+
+## Intentionally Tool-Specific Repo Artifacts
+
+These do not currently require one-to-one Codex repo mirrors:
+
+- `.claude/agents/*.md`
+- `.claude/rules/*.md`
+- `.claude/workflows/*.yaml`
+- `.claude/project.yaml`
+
+Reason: these artifacts primarily express Claude-side orchestration and repo-local tooling assumptions that are already handled differently by Codex platform instructions and tool policy.
+
+## Drift Check
+
+When editing parity-sensitive guidance:
+
+1. Compare `AGENTS.md` and `.claude/CLAUDE.md`.
+2. Compare `.agents/skills/` and `.claude/skills/`.
+3. Confirm any difference is either:
+   - matched in substance
+   - an intentional tool-specific divergence
+   - an explicitly deferred follow-up
+4. Update [parity-audit.md](./parity-audit.md) if the classification changed.
+5. Update [README.md](./README.md) and [workplan.md](./workplan.md) if the feature phase status changed.
+
+## Deferred Follow-Up
+
+- Claude skill files may still contain more detailed step-by-step instructions than their Codex equivalents even when the workflow intent matches.
+- If future repo changes make Claude-only rules or workflow descriptors operationally important for Codex, revisit whether repo-local Codex mirrors should be added.

--- a/docs/1.0/001-IN-PROGRESS/codex-claude-parity/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/codex-claude-parity/prd.md
@@ -1,0 +1,49 @@
+# PRD: Codex and Claude Parity
+
+## Problem Statement
+
+Ensure skill and directive parity between Codex and Claude Code in this repository so both agents can operate against the same workflows, project rules, and expected session behaviors without drift.
+
+Today, parity is partially implied but not guaranteed. Repo-local instructions already say some files should stay in sync, and both systems have workflow-specific skills, but there is no single maintained parity pass that answers:
+
+1. Which directives are meant to match exactly?
+2. Which workflows exist on one side but not the other?
+3. Which differences are intentional because of tool constraints, and which are just drift?
+4. What is the canonical maintenance path for future updates?
+
+Without that clarity, the repo risks duplicated-but-divergent instructions, one-sided workflows, and future agent behavior differences that are hard to detect until they break a session.
+
+## User Stories
+
+1. As a maintainer, I want Codex and Claude Code to expose equivalent repo workflows so feature setup, implementation, review, and close-out behave consistently.
+2. As a maintainer, I want shared agent instructions to stay synchronized so I do not have to debug agent-specific drift.
+3. As a future agent, I want one clear parity artifact so I can tell what should match, what differs intentionally, and how to keep it aligned.
+4. As a maintainer, I want low-value one-sided instructions removed instead of copied forward forever.
+
+## Acceptance Criteria
+
+- Every active Claude-oriented workflow in the repo has a Codex equivalent, or is explicitly documented as intentionally unsupported.
+- Every active Codex-oriented workflow in the repo has a Claude equivalent, or is explicitly documented as intentionally unsupported.
+- Workspace instructions that are meant to stay in sync are updated together and verified for parity.
+- Session-start and session-end guidance match in substance across both agent systems.
+- A maintainer can inspect one canonical parity artifact and understand which skills and directives are matched, which are intentionally different, and what follow-up work remains.
+
+## Out of Scope
+
+- Adding brand-new workflows that neither system currently supports.
+- Changing underlying Codex or Claude product capabilities.
+- Rewriting unrelated feature documentation.
+- Broad repo refactors unrelated to agent parity.
+
+## Dependencies
+
+- Accurate inventory of existing Codex repo-local skills.
+- Accurate inventory of Claude-oriented instructions and workflow definitions.
+- A decision on whether parity should be enforced by duplicated files, a canonical shared source, or an explicit sync procedure.
+
+## Open Questions
+
+1. What should be the canonical source for shared agent guidance: `AGENTS.md`, `.claude/CLAUDE.md`, or a third shared doc?
+2. Are there Claude-specific workflows that should be retired instead of ported?
+3. Are there Codex-specific workflows that should remain intentionally different because of tool constraints?
+4. Should parity target wording-level sync, behavior-level sync, or both?

--- a/docs/1.0/001-IN-PROGRESS/codex-claude-parity/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/codex-claude-parity/workplan.md
@@ -1,0 +1,120 @@
+# Codex and Claude Parity -- Workplan
+
+**Source PRD:** [prd.md](./prd.md)
+**Created:** 2026-04-17
+
+---
+
+## GitHub Tracking
+
+| Item | Link |
+|------|------|
+| Parent Issue | TBD |
+
+### Implementation Issues
+
+| Phase | Issue | Description |
+|-------|-------|-------------|
+| Phase 1 | TBD | Audit Codex and Claude directives, skills, and workflow coverage |
+| Phase 2 | TBD | Align shared repo instructions and define canonical sync path |
+| Phase 3 | TBD | Add, remove, or align workflows to achieve parity |
+| Phase 4 | TBD | Verify parity and add drift-prevention artifact |
+
+---
+
+## Technical Approach
+
+### Affected Areas
+
+- `AGENTS.md`
+- `.claude/CLAUDE.md`
+- `.agents/skills/`
+- Claude-oriented workflow definitions and supporting docs
+- Any parity summary or maintenance artifact added by this feature
+
+### Strategy
+
+1. Inventory directives and skills on both sides.
+2. Classify each item as matched, missing on Codex, missing on Claude, or intentionally divergent.
+3. Normalize shared operating guidance first.
+4. Add, remove, or align skills and workflow docs to close unintended gaps.
+5. Produce a parity summary artifact that makes future drift easy to detect.
+
+---
+
+## Phase 1: Audit
+
+**Goal:** Establish the real parity baseline before changing any instructions or workflows.
+
+**Audit Artifact:** [parity-audit.md](./parity-audit.md)
+
+### Tasks
+
+- [x] Inventory Codex repo-local skills and workflow docs
+- [x] Inventory Claude-oriented instructions and workflow docs
+- [x] Map equivalent items across both systems
+- [x] Identify accidental gaps, duplicate concepts, and intentional differences
+- [x] Capture audit findings in a parity artifact or feature-local audit note
+
+### Acceptance Criteria
+
+- Clear inventory exists for both agent systems
+- Every item is classified as matched, missing, duplicate, or intentionally divergent
+- The repo has a written baseline for parity work rather than relying on memory
+
+---
+
+## Phase 2: Directive Alignment
+
+**Goal:** Synchronize shared repo instructions and remove contradictions.
+
+### Tasks
+
+- [x] Align `AGENTS.md` and `.claude/CLAUDE.md` where they are meant to stay in sync
+- [x] Remove stale or contradictory guidance between the two systems
+- [x] Decide and document the canonical maintenance path for shared directives
+- [x] Preserve only intentional differences tied to real tool constraints
+
+### Acceptance Criteria
+
+- Shared instructions match in substance across both systems
+- Any remaining differences are explicitly justified
+- Maintainers can tell where future directive updates should start
+
+---
+
+## Phase 3: Skill and Workflow Parity
+
+**Goal:** Close unintended workflow gaps between Codex and Claude.
+
+### Tasks
+
+- [x] Add missing equivalents where parity is required
+- [x] Remove or deprecate one-sided workflows that should not persist
+- [x] Align session-start, session-end, and feature lifecycle workflow coverage
+- [x] Verify naming and behavior are coherent enough to prevent future drift
+
+### Acceptance Criteria
+
+- Workflow coverage is equivalent across both systems for active repo processes
+- One-sided workflows are either removed or explicitly justified
+- Session bootstrap and wrap-up behavior align in substance
+
+---
+
+## Phase 4: Verification and Drift Prevention
+
+**Goal:** Leave behind a durable parity record and maintenance guidance.
+
+### Tasks
+
+- [x] Produce a canonical parity summary or checklist
+- [x] Verify both systems can follow the same repo lifecycle at a high level
+- [x] Add a lightweight maintenance note explaining how to keep parity intact
+- [x] Record any follow-up gaps that are intentionally deferred
+
+### Acceptance Criteria
+
+- A maintainer can inspect one artifact and understand current parity state
+- Future changes have a documented sync path instead of ad hoc duplication
+- Deferred work is explicit rather than implicit drift


### PR DESCRIPTION
## Summary
- add the codex-claude-parity feature docs, including the PRD, workplan, parity audit, and maintenance checklist
- align AGENTS.md with the shared guidance in .claude/CLAUDE.md and make the canonical sync path explicit in both files
- add the Codex feature-extend skill and align the Codex session-start, session-end, and feature-help skills with the Claude workflow substance
- record the remaining Claude-only repo artifacts as intentional tool-specific surfaces rather than accidental drift

## Test Plan
- not run; documentation and repo-local skill definitions only

## Notes
- delegation policy remains intentionally different between Codex and Claude because of tool constraints
- origin/main was fetched and matched at the start of the audit baseline