### PR TITLE
debug(midi-macro-bridge): byte trace on idle path; Logic Pro validated

### DIFF
--- a/services/midi-macro-bridge/src/main.rs
+++ b/services/midi-macro-bridge/src/main.rs
@@ -408,6 +408,17 @@ fn handle_mcu_byte_idle(
     pair: &Option<Rc<RefCell<VirtualMcuPair>>>,
     tracker: &mut PositionTracker,
 ) {
+    // Mirror of the locate-path byte trace, so a single RUST_LOG=debug
+    // run captures both idle and locate windows. Useful for diagnosing
+    // DAWs that only emit position info on rare events (e.g. Logic's
+    // surface-init bursts) — the burst hits handle_mcu_byte_idle, not
+    // wait_for_position_change.
+    let hex = bytes
+        .iter()
+        .map(|b| format!("{b:02X}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    tracing::debug!(len = bytes.len(), %hex, "idle: rx bytes");
     if let Some(pair) = pair {
         if let Some(model) = mcu::parse_heartbeat_query(bytes) {
             if model == mcu::MCU_MODEL_ID {
@@ -419,7 +430,23 @@ fn handle_mcu_byte_idle(
         }
     }
     if let Some(update) = mcu::parse_cc_display(bytes) {
-        tracker.apply(update);
+        let before_bar = tracker.current_bar();
+        if let Some(pos) = tracker.apply(update) {
+            tracing::debug!(
+                idx = update.index,
+                ?update.value,
+                before_bar,
+                after_bar = pos.bar,
+                "idle: bar-changing update"
+            );
+        } else {
+            tracing::debug!(
+                idx = update.index,
+                ?update.value,
+                tracker_bar = tracker.current_bar(),
+                "idle: non-bar update applied"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Mirrors PR #318's locate-path debug-level byte trace into `handle_mcu_byte_idle`. With both paths instrumented, a single `RUST_LOG=debug` bridge run captures every byte the DAW emits across its full lifetime (startup handshake, idle bursts, and locate windows).
- Earned its keep diagnosing Logic Pro: Logic emits position bursts on surface re-init events between locates, not during them, so the idle-path trace was needed to distinguish "didn't see position info" from "saw it but ignored it."
- Confirms Logic Pro works with the existing closed-loop `LocateController` — no parser or controller changes required. Latency runs ~2× LUNA's, comfortably inside the 500 ms `position_timeout`.

## Test plan

- [x] All 85 unit tests pass (`cargo test`)
- [x] Release build clean (`cargo build --release`)
- [x] Hardware: Logic Pro locate `5 → 17` reached in 12 iters, 98 ms avg latency
- [x] Hardware: Logic Pro locate `17 → 33` reached in 16 iters, 99 ms avg latency
- [x] Hardware: LUNA still works (no behaviour change to data path; only added log statements)
- [ ] Confirm `RUST_LOG=info` (default) is unaffected — debug logs gated behind log level