### PR TITLE
feat(library): chevron architecture + multi-select batch export + v3 UX

### DIFF
--- a/.claude/rules/chevron-sizing.md
+++ b/.claude/rules/chevron-sizing.md
@@ -1,0 +1,96 @@
+# Chevron sizing — one component, one CSS rule, one source of truth
+
+Every disclosure / collapse / expand chevron in the editor MUST be
+rendered via the `AcChevron` React component. There is exactly one
+chevron CSS rule in the entire codebase (`.ac-chevron` in
+`modules/editor-core/src/design/chevron-primitives.css`), and the
+component is the only thing that emits it.
+
+## The rule
+
+**Do not write chevron CSS. Render the component.**
+
+```tsx
+import { AcChevron } from '@audiocontrol/editor-core';
+
+<AcChevron expanded={isExpanded} />
+```
+
+The component owns the glyph (▾ / ▸), the 1.1rem square box, the
+accent color, and the transition. None of those are exposed as
+props — the abstraction is fully closed.
+
+If your disclosure-toggle button needs a wrapper class (for cursor /
+padding / hit-area chrome), name it after the wrapper's ROLE — e.g.,
+`.ac-tree-disclosure-btn`, `.ac-list-bank-toggle`,
+`.ac-device-memory-section-eyebrow` — and put the AcChevron inside.
+**Never name a class after the glyph it wraps.** A class containing
+the substring "chevron" anywhere outside the canonical file fails
+the pre-commit gate.
+
+## Why the rule has this exact shape
+
+It was violated four+ times across sessions despite being documented
+in memory (`feedback_chevron_size.md`) and in inline CSS comments.
+Each violation reached the operator's browser because the prior
+architecture had FOUR hand-coded chevron CSS classes
+(`.ac-list-bank-chevron`, `.ac-tree-chevron`, `.ac-tree-chevron-btn`,
+`.ac-device-memory-section-eyebrow-chevron`) that "agreed by
+convention." The fourth violation (May 2026) was a 1rem drift on the
+device-memory section eyebrow that the prior allow-list gate didn't
+catch — the gate checked class NAMES, not VALUES, so an allow-listed
+class could quietly drift without tripping anything.
+
+The new architecture closes the pathology structurally:
+
+1. **One CSS class** (`.ac-chevron`) in **one file** (chevron-primitives.css)
+2. **One React component** (`AcChevron`) that emits that class
+3. **A pre-commit gate** (`tools/check-chevron-sizing.sh`) that fails
+   the build if any other CSS file declares a class containing the
+   substring "chevron"
+
+Agents physically cannot author a divergent chevron without removing
+the gate or editing the canonical file — and either of those needs
+explicit operator approval because the diff is obvious.
+
+## What this gate does NOT catch
+
+- **Misuse of the component** — e.g., shrinking the rendered glyph
+  via a parent-container `font-size:` override that cascades into
+  `.ac-chevron`. If you encounter this pattern in the wild, add a
+  unit test that asserts `getComputedStyle(chevron).fontSize ===
+  '17.6px'` (1.1rem at the default 16px root).
+- **Visual regressions where the chevron is the right size but the
+  contrast is wrong** (e.g., accent-on-accent background). Verify
+  visually with a Playwright screenshot when shipping changes that
+  touch chevron-bearing surfaces.
+- **The home-page `.marker` glyph** inside native `<details>` /
+  `<summary>` elements. That glyph stays a separate name + rule
+  because the native `<details>` element can't mount a React
+  component as its marker without converting the disclosure to a
+  controlled component. The exception is documented at its
+  declaration site in `_shared.css`. **Do not pattern off it for
+  editor surfaces.**
+
+## Process discipline when working on a disclosure UI
+
+1. Need a disclosure chevron in JSX? Import AcChevron:
+   ```tsx
+   import { AcChevron } from '@audiocontrol/editor-core';
+   ```
+2. Need a wrapping toggle? Name it after its role
+   (`.ac-foo-toggle`, `.ac-bar-disclosure-btn`). The class may NOT
+   contain the substring "chevron". The gate enforces this.
+3. After any change touching a disclosure surface, run
+   `make check-chevron-sizing` (the gate runs in pre-commit anyway,
+   but local verification saves a round-trip).
+4. After any change that changes which class wraps the chevron,
+   re-screenshot the affected pages per the CSS refactor protocol
+   (`.claude/rules/css-refactor.md`).
+
+## Files involved
+
+- `modules/editor-core/src/components/AcChevron.tsx` — the component
+- `modules/editor-core/src/design/chevron-primitives.css` — the lone CSS rule
+- `tools/check-chevron-sizing.sh` — the pre-commit gate
+- `Makefile` — `check-chevron-sizing` target wired into the build

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,4 +23,6 @@ set -euo pipefail
 if git diff --cached --name-only --diff-filter=ACM | grep -qE '\.(css|scss)$'; then
   echo "pre-commit: checking for new cross-page CSS duplication…"
   make --no-print-directory check-css-duplication
+  echo "pre-commit: checking for chevron-named classes outside the canonical primitive…"
+  make --no-print-directory check-chevron-sizing
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ pnpm-lock.yamltmp/
 
 # Garbage
 tmp/
+.tmp/
 # Generated license files
 modules/*/LICENSE
 *~

--- a/DEVELOPMENT-NOTES.md
+++ b/DEVELOPMENT-NOTES.md
@@ -11,6 +11,56 @@ Each correction is tagged by category for pattern analysis:
 
 ---
 
+## 2026-05-21: roland-bugfix — chevron architecture, multi-select batch export, v3 UX work
+
+### Feature: roland-bugfix
+### Worktree: audiocontrol-roland-bugfix
+
+### Goal
+
+Multi-turn session driving bug-fix + design-language refinement against the Roland S-330/S-550 editor. Started with BUG-001 (export-to-library silent failure), grew into a full v3 redesign of the export dialogs, then library-tree UX work (selection, scope grouping, collapsible sections, hierarchy v3), then library-move bug fixes, then the chevron architecture rewrite triggered by the operator's fourth chevron-size violation, then task #36 device-memory multi-select + batch drag-export.
+
+### Accomplished
+
+One commit on `feature/roland-bugfix` — `51f3149b` (54 files, +3,379/-610). Pre-commit gates green (CSS duplication + chevron). Per concern:
+
+**Chevron architecture rewrite.** Four hand-coded chevron CSS classes consolidated into ONE: the AcChevron React component backed by `.ac-chevron` in `modules/editor-core/src/design/chevron-primitives.css`. Eight JSX consumers migrated to `<AcChevron expanded={...} />`. Wrapping button renamed `.ac-tree-chevron-btn` → `.ac-tree-disclosure-btn` (a button wrapping a chevron isn't a chevron). Gate rewritten: forbids the substring "chevron" in any CSS class outside the canonical file (prior allow-list-by-name approach missed silent value drift — exactly how the fourth violation happened). Pre-commit hook now invokes the chevron check. Rule doc + memory updated. Verification: `bash tools/check-chevron-sizing.sh` green; `make` green.
+
+**Multi-select + batch export (task #36, closes).** Device-memory panel grows ctrl/shift-click multi-select. Drag of any member of a >1 set emits a batch payload (`DeviceDragData.indices`) that opens a new `BatchExportDrawer` instead of the single-item dialog. `handleBatchExport` loops items serially, calling `exportToneToDirectory` / `exportPatchToDirectory` per item with cross-item byte progress and single library-refresh at the end. Symmetric tone + patch paths. Wiring tests `D-LIB-28` (tone batch) + `D-LIB-29` (patch batch) cover plain/ctrl-click sequence, `data-multi-selected` attribute, drag/drop, drawer mount. Verification: `make test-wiring-roland ARGS='library-flows-dnd.spec.ts'` → 12/12 pass.
+
+**v3 UX work (accumulated across prior session segments).** Export dialogs migrated to SlideDrawer + SteppedProgressDrawer with step-log body (kills BUG-001 empty-catch silent-failure shape). Auto-fetch missing tones during patch export. Auto-refresh library after export. Library tree selection drives preview pane. Device-memory item preview affordances (Edit / Export). v3 button typography rollout. Drop-on-folder export honors target subfolder path. MIME-gated dragover (no tone drag lighting up patches section). Tree-node `data-kind` attribute. Collapsible library sections. Scope grouping (DEVICE / COMMON header bands). Library hierarchy v3 (typography ladder + mono KindTag + inset section bands). Library moves: `useRolandLibraryStrategy.moveItem`, `useLibraryOperations.moveItem` capability, payload-meta spread fix, stale-selection clear after move, multi-select anchor highlight. s550 surface-token override (was falling through to flat defaults). Tone editor pitch+LFO tab layout. Wiring tests D-LIB-24 through D-LIB-29 (six new). New e2e test for device→library drag-drop round trip. New `useStepHistory` hook converts `OperationProgress` → `ProgressStep[]`.
+
+### Didn't Work
+
+**Chevron drift went undetected for the FOURTH time** until the operator screen-grepped the device-memory section eyebrow against the library section eyebrow and noticed the 1rem vs 1.1rem mismatch. Prior protection was a gate that allow-listed chevron class names — an allow-listed class could silently change its values without tripping the gate. Fix: structural — one component, one CSS file, gate forbids the substring.
+
+**Multi-select dispatcher's first wiring-test run failed** because the prior-anchor seed read `lastToneAnchorRef.current` inside the `setMultiTones` updater, but React batches state updates and runs the updater asynchronously — by then the line `lastToneAnchorRef.current = index` had already clobbered the ref. Fix: capture `const priorAnchor = lastToneAnchorRef.current` before the setter call. Same fix applied to handlePatchClick. Both visible as the corrected pattern in `DeviceMemoryPanel.tsx`.
+
+**The batch-export flow has acknowledged DRY debt** with single-item handleExportTone/handleExportPatch — both shapes call the same library helpers (`exportToneToDirectory` / `exportPatchToDirectory`) but accumulate progress differently. Extracting a shared core helper would shrink ~80 lines of mostly-duplicated wave-fetch + classify code. Deliberately deferred — the extraction is a meaningful refactor that should be its own dispatch.
+
+### Course Corrections
+
+- **[STRUCTURAL]** Operator: "WHY ARE YOU EVEN ALLOWED TO MAKE THE CHEVRON THE WRONG SIZE??????" — moved chevron correctness from agent-discipline (memory + rule + inline CSS comments) to structural (component + gate). The pattern matters beyond chevrons: when a guideline gets violated repeatedly despite documentation, the guideline needs to become a structural impossibility. Memory + inline comments are weak forms; gates are stronger; closed component abstractions are strongest. Pick the strongest enforcement the design allows.
+- **[STRUCTURAL]** Operator after I proposed a CSS-token-only fix to chevron drift: "Fix this in a way that DOESN'T INVITE FUTURE PATHOLOGICAL BEHAVIOR." The token approach (`var(--ac-chevron-size)` referenced by four classes) still invites future chevron-named CSS class declarations. The component approach removes the abstraction layer entirely so there's nothing to mis-author. Strongest answer to "make it impossible" is "remove the surface where the mistake lives."
+- **[PROCESS]** Operator: "Why haven't you committed anything? What are you waiting for?" — I'd been following the global "NEVER commit unless explicitly asked" rule, but had accumulated 54 files of work. The rule prevents over-eager commits; it doesn't excuse hoarding completed work. When a coherent body of work is done and tested, surface it for commit approval instead of waiting for the operator to notice the buildup.
+- **[PROCESS]** Multiple `<system-reminder>` task-tool nudges throughout the session. Mostly ignored — the task list was being used, and the reminders were heuristic. Worth knowing the reminders fire when no TaskCreate/Update tool has been used "recently" regardless of whether the work warrants it.
+
+### Quantitative
+
+- User messages: ~38 in this session (per the summary count; many across the compaction boundary)
+- Commits: 1 (51f3149b — covering work that should arguably have been 5–8 commits if it had landed incrementally)
+- User corrections: ~5 substantive (the SCREAMED chevron rebuke; "DOESN'T INVITE FUTURE PATHOLOGICAL BEHAVIOR"; "Those 'four people' were ALL YOU"; "Why haven't you committed"; multiple smaller redirects on UX details)
+- Wiring tests added: 6 (D-LIB-24 through D-LIB-29)
+- E2E tests added: 1 (device-library-roundtrip)
+- New chevron-related CSS classes in the system: 1 (down from 4)
+
+### Insights
+
+- **One component beats one token beats four agreed-by-convention classes.** When chevron drift hit a fourth time, the operator wouldn't accept a token-only fix because tokens still allow per-context chevron CSS classes (just makes them less likely to drift). The component fix removes the surface entirely — agents can't author what they can't write. Apply the same shape next time a recurring violation needs structural protection.
+- **Compound `useState` updater + ref-mutation needs ordering care.** The dispatcher bug (anchor ref clobbered before updater reads it) is generic to any "capture state into a queued setter" pattern. The fix shape — `const priorX = refX.current` before the setter — is worth remembering for similar patterns.
+- **Pre-commit gates that allow-list by NAME miss VALUE drift.** Wherever a project has an allow-list-by-identity gate (chevron class names, eslint rule overrides, etc.), audit whether the gated value can silently change without tripping the gate. The chevron gate's first version was an example of this anti-pattern.
+- **The DRY refactor of handleExportTone / handleExportPatch / handleBatchExport is real debt.** Three places carry the wave-fetch + classify + write loop with subtly different progress accounting. Worth a dedicated extraction-helpers dispatch when someone's next in this hook for any reason.
+
 ## 2026-05-14 (evening): s550-support — 9R-A.2 spec migration + 9R-A.3 inventory rewrite (full closure)
 
 ### Feature: s550-support

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ SYNTH_CORE_SRC         := $(shell find $(MODULES_DIR)/synth-core/src -name '*.ts
 SAMPLE_EDITOR_SRC      := $(shell find $(MODULES_DIR)/sample-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
 AKAI_S3K_EDITOR_SRC    := $(shell find $(MODULES_DIR)/akai-s3k-editor/src -name '*.ts' -o -name '*.tsx' -o -name '*.css' 2>/dev/null)
 
-.PHONY: build clean clean-deps ensure-devenv ensure-playwright check-midi-server test-e2e-roland test-e2e-roland-device test-e2e-roland-device-conformance test-e2e-roland-library test-e2e-roland-device-library test-e2e-roland-ui test-probe-roland probe-roland-diag test-e2e-s3k-device test-e2e-s3k-library test-e2e-s3k-scsi test-e2e-s3k-device-library check-scsi-bridge test-scsi-write-validation dev-scsi test-e2e-common-library-s3k test-e2e-common-library-roland test-ui-s3k test-ui-roland test-wiring-roland test-rendering-roland build-midi-macro-bridge record-fixtures-roland record-fixtures-roland-s330 record-fixtures-roland-s550 check-fixture-drift check-coverage-roland
+.PHONY: build clean clean-deps ensure-devenv ensure-playwright check-midi-server test-e2e-roland test-e2e-roland-device test-e2e-roland-device-conformance test-e2e-roland-library test-e2e-roland-device-library test-e2e-roland-ui test-probe-roland probe-roland-diag test-e2e-s3k-device test-e2e-s3k-library test-e2e-s3k-scsi test-e2e-s3k-device-library check-scsi-bridge test-scsi-write-validation dev-scsi test-e2e-common-library-s3k test-e2e-common-library-roland test-ui-s3k test-ui-roland test-wiring-roland test-rendering-roland build-midi-macro-bridge record-fixtures-roland record-fixtures-roland-s330 record-fixtures-roland-s550 check-fixture-drift check-coverage-roland check-chevron-sizing
 
 build: $(ALL_STAMPS)
 
@@ -273,6 +273,23 @@ test-rendering-roland: $(ROLAND_SXX0_EDITOR) ensure-playwright
 # generated manifest. Workplan 9R-A.1 T8 + 9R-A.2; reform spec §6.
 check-coverage-roland: $(ROLAND_SXX0_EDITOR) ensure-playwright
 	$(DEVENV_RUN) "pnpm run check-coverage"
+
+# Chevron-sizing gate. Fails when a NEW chevron-named CSS class (one
+# not on the allow-list in `tools/check-chevron-sizing.sh`) declares
+# its own font-size / width / height. Every disclosure / collapse
+# chevron in the editor must reuse the canonical .ac-list-bank-chevron
+# class (1.1rem font + 1.1rem box + accent) so the affordance is
+# obvious at glance and the combined hit area clears WCAG AA target
+# floors. The rule predates this gate as memory + design-system
+# guidance but kept getting violated; the gate turns the rule into
+# a build-time block independent of any agent's discipline.
+# See `.claude/rules/chevron-sizing.md` for the operator-facing rule.
+# (Rewritten 2026-05-21: the gate now forbids the substring "chevron"
+# in any CSS class outside the canonical primitive, rather than allow-
+# listing per-context chevron classes by name. Closes the drift loophole
+# where an allow-listed class could silently change its sizing.)
+check-chevron-sizing:
+	./tools/check-chevron-sizing.sh
 
 # Cross-page CSS duplication gate. Fails when a NEW `.pageA__X` /
 # `.pageB__X` rule pair appears whose body overlaps with the other —

--- a/docs/1.0/001-IN-PROGRESS/roland-bugfix/README.md
+++ b/docs/1.0/001-IN-PROGRESS/roland-bugfix/README.md
@@ -1,0 +1,24 @@
+# Roland Bug-Fix Catchment
+
+Open-ended catchment branch for post-merge bug fixes against the just-merged Roland S-330 / S-550 editor surface (s550-support PRs [#433](https://github.com/audiocontrol-org/audiocontrol/pull/433) + [#434](https://github.com/audiocontrol-org/audiocontrol/pull/434), merged 2026-05-20).
+
+## Status
+
+| Phase | Status | Notes |
+|-------|--------|-------|
+| Phase 1: Rolling Bug-Fix Pass | In Progress | Open-ended; operator-declared completion |
+
+## Documentation
+
+- [PRD](./prd.md) — problem statement, scope, success criteria
+- [Workplan](./workplan.md) — technical approach, bug triage table, per-fix gates
+- [Implementation Summary](./implementation-summary.md) — post-completion report (placeholder)
+
+## GitHub Tracking
+
+- **Parent issue:** TBD
+
+## Worktree
+
+- **Path:** `~/work/audiocontrol-work/audiocontrol-roland-bugfix`
+- **Branch:** `feature/roland-bugfix`

--- a/docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md
+++ b/docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md
@@ -1,0 +1,64 @@
+# Audit Log — feature/roland-bugfix
+
+This document is the feature-local audit log for `feature/roland-bugfix`.
+New findings follow the project-wide protocol in [AUDITOR-IMPLEMENTER-PROTOCOL.md](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/AUDITOR-IMPLEMENTER-PROTOCOL.md).
+
+Canonical grep queue:
+
+- unfinished work: `grep -nE "^Status: (open|acknowledged|fixed-)" docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md`
+- new findings: `grep -nE "^Status: open" docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md`
+- awaiting verification: `grep -nE "^Status: fixed-" docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md`
+
+---
+
+## 2026-05-21 PR #440 Review
+
+### Ctrl/Cmd-click mutates the device-memory anchor, so the next Shift-click range starts from the wrong slot
+
+Finding-ID: AUDIT-20260521-01
+Status:     fixed-awaiting-verification
+Severity:   high
+Surface:    `modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx`
+
+Fix: removed the `lastToneAnchorRef.current = index` / `lastPatchAnchorRef.current = index` assignment from the ctrl/meta branch in both `handleToneClick` and `handlePatchClick`. The anchor now only moves on plain click (or after a shift-click implicitly via the operator's next plain click). Inline comments updated to make the contract explicit. Regression test: `D-LIB-32` covers the plain → ctrl → shift sequence and asserts the resulting multi-set is `{T11..T15}` (range from the original anchor `T11`), not `{T13..T15}` (range from the most recent ctrl-click).
+
+The new device-memory multi-select logic contradicts its own documented anchor behavior and breaks the `Ctrl/Cmd-click` then `Shift-click` workflow. The comment says modifier toggles should keep the page-level anchor where it was, but both handlers overwrite the anchor inside the modifier branch:
+
+- tone path: [DeviceMemoryPanel.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx:156) and [DeviceMemoryPanel.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx:170)
+- patch path: [DeviceMemoryPanel.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx:188) and [DeviceMemoryPanel.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx:201)
+
+Repro:
+
+1. Plain-click `T11` to establish the anchor.
+2. `Cmd/Ctrl-click` `T13` to extend the set.
+3. `Shift-click` `T15`.
+
+Expected: the range extends from the original anchor (`T11`) through `T15`.
+
+Actual: the range starts from the last modifier-clicked slot (`T13`) because the anchor was mutated during step 2.
+
+Evidence the current test coverage misses this exact path: the PR's wiring suite passed (`make test-wiring-roland ARGS='library-flows-dnd.spec.ts'`), but the new specs cover plain-click plus modifier toggles and non-contiguous modifier selection, not the `ctrl/meta -> shift` sequence.
+
+This is a load-bearing correctness bug in the headline multi-select workflow introduced by PR #440.
+
+### Export drawers hard-code `S330` in user-facing copy, so S-550 mode is mislabeled
+
+Finding-ID: AUDIT-20260521-02
+Status:     fixed-awaiting-verification
+Severity:   medium
+Surface:    `modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx`, `ExportPatchDialog.tsx`, `BatchExportDrawer.tsx`
+
+Fix: replaced the hardcoded `S330` literal in all three drawers with `deviceName` extracted from `useDeviceConfig()` and uppercased at render. `ExportToneDialog` and `ExportPatchDialog` already called `useDeviceConfig()` for `memoryLayout`; both now destructure `deviceName` alongside it and route it through the form-body components. `BatchExportDrawer` didn't call the hook — added the import + call + threaded `deviceName` through `BatchFormBody`. Each rendered span gets a `data-testid={kind}-device-name` for direct test assertion. Regression test: `D-LIB-33` mounts the export drawer on the S-550 surface and asserts the eyebrow span resolves to `S-550`.
+
+
+The new export UI hard-codes `S330` in three user-facing eyebrow rows instead of deriving the active device name from configuration:
+
+- [ExportToneDialog.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx:183)
+- [ExportPatchDialog.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/ExportPatchDialog.tsx:195)
+- [BatchExportDrawer.tsx](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx:184)
+
+Expected: the eyebrow copy reflects the active Roland surface, the same way slot labels already do via `memoryLayout`.
+
+Actual: all three drawers render `... · LIBRARY · S330`, even when the editor is running in S-550 mode.
+
+This is cross-device UI drift in a shared Roland surface. It likely escaped because the exercised review/test path was S-330-only.

--- a/docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md
+++ b/docs/1.0/001-IN-PROGRESS/roland-bugfix/audit-log.md
@@ -16,7 +16,7 @@ Canonical grep queue:
 ### Ctrl/Cmd-click mutates the device-memory anchor, so the next Shift-click range starts from the wrong slot
 
 Finding-ID: AUDIT-20260521-01
-Status:     fixed-awaiting-verification
+Status:     verified-2026-05-21
 Severity:   high
 Surface:    `modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx`
 
@@ -44,7 +44,7 @@ This is a load-bearing correctness bug in the headline multi-select workflow int
 ### Export drawers hard-code `S330` in user-facing copy, so S-550 mode is mislabeled
 
 Finding-ID: AUDIT-20260521-02
-Status:     fixed-awaiting-verification
+Status:     verified-2026-05-21
 Severity:   medium
 Surface:    `modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx`, `ExportPatchDialog.tsx`, `BatchExportDrawer.tsx`
 

--- a/docs/1.0/001-IN-PROGRESS/roland-bugfix/implementation-summary.md
+++ b/docs/1.0/001-IN-PROGRESS/roland-bugfix/implementation-summary.md
@@ -1,0 +1,43 @@
+# Roland Bug-Fix Catchment - Implementation Summary
+
+**Status:** Draft (placeholder — fill in at operator-declared completion)
+**Completed:** TBD
+**PR:** TBD
+
+---
+
+## Summary
+
+TBD — one paragraph describing the round of fixes shipped, what surface they touched, and what the operator's closure criterion was.
+
+## Bugs Fixed
+
+| ID | Reported | Surface | Description | Status | Commit |
+|----|----------|---------|-------------|--------|--------|
+| *(populate from `workplan.md` triage table at completion)* | | | | | |
+
+## What Shipped
+
+- TBD
+- TBD
+- TBD
+
+## What Was Out of Scope
+
+Carried over from the PRD plus any deferrals discovered mid-pass:
+
+- [#407](https://github.com/audiocontrol-org/audiocontrol/issues/407) (D-SYS page) — missing-affordance enhancement, not a bug
+- [#409](https://github.com/audiocontrol-org/audiocontrol/issues/409) (Copy/Derive) — missing-affordance enhancement, not a bug
+- New features and tone/patch data-model changes — separate PRD
+- TBD — any additional deferrals surfaced during the bugfix pass
+
+## Lessons / Insights
+
+TBD — record patterns from the round (e.g., recurring nucleation sites, primitives that drifted, places where the test gate caught vs missed regressions).
+
+## Verification
+
+- `make test-ui-roland` — green at PR-ready commit
+- `make check-css-duplication` — clean at PR-ready commit
+- Visual verification screenshots — TBD per fix
+- Operator sign-off — TBD (recorded in DEVELOPMENT-NOTES.md at branch close)

--- a/docs/1.0/001-IN-PROGRESS/roland-bugfix/prd.md
+++ b/docs/1.0/001-IN-PROGRESS/roland-bugfix/prd.md
@@ -1,0 +1,59 @@
+# Roland Bug-Fix Catchment - Product Requirements Document
+
+**Created:** 2026-05-20
+**Status:** Draft
+**Owner:** operator
+
+## Problem Statement
+
+The s550-support feature shipped a large redesign of the Roland S-330 / S-550 editors (PRs [#433](https://github.com/audiocontrol-org/audiocontrol/pull/433) + [#434](https://github.com/audiocontrol-org/audiocontrol/pull/434), merged 2026-05-20). Operator-driven use will surface regressions, layout drift, and small bugs that warrant fixes against the just-merged surface. This branch is the catchment for that work.
+
+## User Stories
+
+- As the operator, I want a dedicated branch where post-merge Roland bugs land as discrete commits so that fixes do not entangle with new-feature work
+- As the operator, I want each fix verified against my own reproduction (visual + functional) before it is checked off, so that "green tests" never substitutes for "actually fixed"
+- As a maintainer, I want a single bug-triage table per fix-pass round so that the diff between "shipped" and "still open" is always inspectable in one place
+
+## Success Criteria
+
+**Open-ended — operator declares completion.**
+
+There is no fixed checklist of bugs to fix. Bugs are added to [`workplan.md`](./workplan.md)'s triage table as they are found by the operator; fixes land as individual commits; the branch ships (or stays open for another round) when the operator says so.
+
+The per-fix gates (which are fixed) are recorded in [`workplan.md`](./workplan.md) under Phase 1 acceptance criteria.
+
+## Scope
+
+### In Scope
+
+- Bugs and polish in `modules/roland-sxx0-editor` (primary surface)
+- Bugs in `modules/editor-core` shared primitives that the Roland editors consume, when a Roland-surface bug traces into them
+- Protocol bugs in `modules/sampler-devices` / `modules/sampler-midi`, only if a real hardware repro surfaces one
+- Diagnostic additions in `modules/e2e-infra`, only if a hardware-touching bug needs one
+
+### Out of Scope
+
+- Anything that isn't a bug or polish in the Roland editor surface — new features get their own branch
+- Refactors larger than what is needed to fix a specific bug
+- Tone/patch data-model changes that would require a new PRD
+- [#407](https://github.com/audiocontrol-org/audiocontrol/issues/407) (D-SYS page) — missing-affordance enhancement, not a bug
+- [#409](https://github.com/audiocontrol-org/audiocontrol/issues/409) (Copy/Derive) — missing-affordance enhancement, not a bug
+
+If the operator decides to scope #407 or #409 in, that is an explicit call recorded in the workplan, not a default.
+
+## Dependencies
+
+None. s550-support is merged; the Roland editor surface is stable.
+
+## Open Questions
+
+None at definition time. Bugs come in via operator triage and are recorded in [`workplan.md`](./workplan.md)'s bug triage table as they are surfaced.
+
+## Appendix
+
+### Predecessor Feature
+
+This branch is the bug-fix catchment for the just-merged s550-support feature. See its post-completion report for what was shipped and the known caveats at merge time:
+
+- [s550-support implementation summary](../../003-COMPLETE/s550-support/implementation-summary.md)
+- [s550-support README](../../003-COMPLETE/s550-support/README.md)

--- a/docs/1.0/001-IN-PROGRESS/roland-bugfix/workplan.md
+++ b/docs/1.0/001-IN-PROGRESS/roland-bugfix/workplan.md
@@ -1,0 +1,68 @@
+# Roland Bug-Fix Catchment - Workplan
+
+**Branch:** `feature/roland-bugfix`
+**Worktree:** `~/work/audiocontrol-work/audiocontrol-roland-bugfix`
+
+## Technical Approach
+
+### Modules Affected
+
+- `modules/roland-sxx0-editor` (primary)
+- `modules/editor-core` (only where a shared primitive needs adjustment)
+- Possibly `modules/sampler-devices` / `modules/sampler-midi` (only if a protocol bug surfaces)
+- Possibly `modules/e2e-infra` (only if a hardware-touching repro needs a diagnostic)
+
+### Strategy
+
+- One bug per commit; descriptive commit messages; no sweep refactors.
+- Verify visually (screenshot or test-harness check) before claiming done — `make test-ui-roland` green is not the same as visual correctness.
+- For any CSS edit touching shared rules, run the duplication gate (`make check-css-duplication`) before commit and prefer reuse over new primitives.
+- For any hardware-touching bug, build the diagnostic in `e2e-infra/` before hypothesizing — don't blame the device.
+- After each fix, re-run the load-bearing test gate independently (the controller is the CI gate).
+
+## Phase 1: Rolling Bug-Fix Pass
+
+**Deliverable:** Operator-declared completion. The branch ships (or ships in waves) once the operator says the post-redesign Roland surface is clean enough.
+
+**Tasks:** Added to the triage table below as bugs are reported. No upfront task list — this phase is intentionally open-ended.
+
+### Bug Triage Table
+
+| ID | Reported | Surface | Description | Status | Commit |
+|----|----------|---------|-------------|--------|--------|
+| BUG-001 | 2026-05-20 | LibraryPage — ExportToneDialog / ExportPatchDialog | Drag tone/patch from device to library opens the export dialog, but clicking "Export" does nothing — no progress, no error, no console message. Root cause: the dialog's `try { await onExport(...) } catch { /* parent will handle */ }` swallows the exception, AND the parent hook (`useLibraryExport.handleExportTone` / `handleExportPatch`) throws synchronously on precondition misses (e.g. `!libraryHandle`, `!clientRef.current`) **before** calling `setExportError`, so `operationError` is never set either. Fix: surface the caught exception via `setLocalError(...)` in both dialogs so the existing `OperationErrorBanner` renders the actual failure. | Awaiting operator retest | — |
+| BUG-002 | 2026-05-20 | LibraryPage — ImportToneDialog / ImportSampleDialog | Same empty-catch shape as BUG-001 — sibling occurrences flagged during the BUG-001 investigation. Surface separately to keep one bug per commit per the workplan's "no while-I-was-in-here" rule. | Open | — |
+| BUG-003 | 2026-05-20 | E2E `device-library-roundtrip.spec.ts` "tone round trip" | Test hangs at `Click locator('a[href$="/tones"]')` during navigation from the import-success state back to the Tones page. Pre-existing, unrelated to BUG-001 (surfaced because we re-ran the e2e gate while verifying BUG-001). Likely the tones nav link selector drifted or the link is being intercepted by a residual dialog/overlay. Existing test never actually verifies the `export-confirm` click path because it dies upstream. | Open | — |
+| BUG-004 | 2026-05-20 | E2E `device-library-autofit.spec.ts` "tone auto-fit round trip" | Test fails finding `button:has-text("Refresh Device")` — UI affordance has been removed or renamed and the spec wasn't updated. Surfaced alongside BUG-003. | Open | — |
+
+### Per-Fix Acceptance Criteria
+
+Each fix must satisfy all of:
+
+- Visual verification of the reproduction (screenshot or test-harness check)
+- `make test-ui-roland` green at the fix commit
+- `make check-css-duplication` clean at the fix commit (only if CSS touched)
+- Operator confirms the bug is resolved before the row is marked `Closed`
+
+A fix is not "done" until the operator has confirmed the row. `Closed` in the table means operator-confirmed.
+
+## Pre-commit Discipline
+
+- One bug per commit; descriptive subject; no sweep refactors slipped in alongside a fix
+- No "while I was in here" sibling changes — they get their own commit and their own triage row
+- For hardware-touching bugs, ship the diagnostic alongside the fix; don't fabricate device-failure narratives without first proving four things: (a) the request the editor sent was correct, (b) the response the device returned was parsed correctly, (c) the parsed response was rendered correctly, (d) the round-trip survives a re-readback
+- The controller re-runs the load-bearing test gate independently after every implementer dispatch — the implementer's reported pass count is a claim, not evidence (see [`.claude/rules/agent-discipline.md`](/Users/orion/work/audiocontrol-work/audiocontrol-roland-bugfix/.claude/rules/agent-discipline.md))
+
+## GitHub Tracking
+
+- **Parent issue:** TBD (created via `/feature-issues`)
+- **Implementation issues:** per-bug, opened as found; each triage row links its issue number when one is filed
+
+## Out of Scope
+
+Repeated from the PRD for in-context reference:
+
+- New features or capability additions — those get their own branch
+- Refactors larger than what's needed to fix a specific bug
+- Tone/patch data-model changes that would require a new PRD
+- [#407](https://github.com/audiocontrol-org/audiocontrol/issues/407) (D-SYS page) and [#409](https://github.com/audiocontrol-org/audiocontrol/issues/409) (Copy/Derive) — missing-affordance enhancements, not bugs

--- a/modules/akai-s3k-editor/test/e2e/device-library-expandable-programs.spec.ts
+++ b/modules/akai-s3k-editor/test/e2e/device-library-expandable-programs.spec.ts
@@ -229,14 +229,17 @@ test.describe('S3K Library Expandable Programs', () => {
     }
 
     // Step 8: Verify expandability -- the program's tree row should have a chevron
-    // Navigate up from the name to the row element to find the chevron button
+    // Navigate up from the name to the row element to find the disclosure button.
+    // The wrapping button class is .ac-tree-disclosure-btn (renamed from
+    // .ac-tree-chevron-btn when the chevron primitive was consolidated into
+    // a single AcChevron component, 2026-05-21).
     const programRow = programTreeNode.locator('..').locator('..');
-    const chevron = programRow.locator('.ac-tree-chevron-btn').first();
+    const chevron = programRow.locator('.ac-tree-disclosure-btn').first();
 
     // The chevron may also be a sibling of the tree node name container
     const altChevron = page.locator('.ac-tree-node', { has: programTreeNode })
       .first()
-      .locator('.ac-tree-chevron-btn');
+      .locator('.ac-tree-disclosure-btn');
 
     const chevronLocator = chevron.or(altChevron).first();
     await expect(chevronLocator).toBeVisible({ timeout: UI_TIMEOUT_MS });

--- a/modules/editor-core/src/components/AcChevron.tsx
+++ b/modules/editor-core/src/components/AcChevron.tsx
@@ -1,0 +1,41 @@
+/**
+ * AcChevron — the ONLY disclosure-chevron primitive in the editor.
+ *
+ * Every collapse / expand affordance MUST render this component. The
+ * component owns the glyph (▾ / ▸), the 1.1rem square box, the accent
+ * color, and the transition. None of those are exposed as props — the
+ * abstraction is intentionally fully closed so consumers cannot accept
+ * a per-context size or color.
+ *
+ * Background — why this exists as a component rather than a CSS class:
+ *
+ *   Prior architecture had four hand-coded CSS classes
+ *   (`.ac-list-bank-chevron`, `.ac-tree-chevron`, `.ac-tree-chevron-btn`,
+ *   `.ac-device-memory-section-eyebrow-chevron`) that "agreed" by
+ *   convention. One drifted to `1rem` without anyone noticing — caught
+ *   by the operator on 2026-05-21. The pre-commit chevron-sizing gate
+ *   allow-listed the classes by name, so an allow-listed class could
+ *   silently drift on a future edit without tripping the gate.
+ *
+ *   Replacing those four classes with this one component closes the
+ *   pathology structurally: there's no class name to redeclare, no
+ *   sizing prop to override, and the gate now fails on any CSS file
+ *   that contains the literal word "chevron" outside this file's
+ *   companion stylesheet. Agents cannot ship a divergent chevron
+ *   without consciously editing AcChevron.tsx + its sole CSS rule.
+ */
+
+import React from 'react';
+
+export interface AcChevronProps {
+  /** Whether the disclosure is expanded (true → ▾) or collapsed (false → ▸). */
+  expanded?: boolean;
+}
+
+export function AcChevron({ expanded }: AcChevronProps): JSX.Element {
+  return (
+    <span className="ac-chevron" data-expanded={expanded ? 'true' : 'false'} aria-hidden="true">
+      {expanded ? '▾' : '▸'}
+    </span>
+  );
+}

--- a/modules/editor-core/src/components/index.ts
+++ b/modules/editor-core/src/components/index.ts
@@ -7,6 +7,7 @@ export {
 
 // v3 atomic control primitives (Phase 9 Task 4.0)
 export { AcCheckbox, type AcCheckboxProps } from './AcCheckbox';
+export { AcChevron, type AcChevronProps } from './AcChevron';
 export {
   AcRangeBar,
   type AcRangeBarProps,
@@ -96,6 +97,8 @@ export {
   LoadingBar,
   SlideDrawer,
   SteppedProgressDrawer,
+  StepRow,
+  StepIcon,
   type SteppedProgressDrawerProps,
   type ProgressStep,
   type StepStatus,

--- a/modules/editor-core/src/components/library/PluginLibraryBrowser.tsx
+++ b/modules/editor-core/src/components/library/PluginLibraryBrowser.tsx
@@ -359,8 +359,17 @@ export function PluginLibraryBrowser({
           setMultiSelectedIds(new Set([...multiSelectedIds, ...rangeIds]));
         }
       } else {
-        // Toggle select (Ctrl/Cmd)
+        // Toggle select (Ctrl/Cmd) — first Ctrl-click after a plain
+        // click needs to seed the prior single-selection (the anchor)
+        // into the set, otherwise TreeView's `isSelected` check
+        // (`selectedIds.has(id)`) ignores the anchor's `selectedId`
+        // entirely and the anchor row reads as unselected. The user
+        // sees their original click "vanish" the moment they
+        // Ctrl-click a sibling.
         const next = new Set(multiSelectedIds);
+        if (next.size === 0 && lastSelectedIdRef.current && lastSelectedIdRef.current !== node.id) {
+          next.add(lastSelectedIdRef.current);
+        }
         if (next.has(node.id)) {
           next.delete(node.id);
         } else {
@@ -638,15 +647,30 @@ export function PluginLibraryBrowser({
         setDropIsMove(true);
         return;
       }
-      // External drops: OS files or custom MIME types (e.g., device memory items)
-      if (onExternalDrop && e.dataTransfer.types.length > 0) {
-        e.preventDefault();
-        e.dataTransfer.dropEffect = 'copy';
-        setDropTargetCategory(categoryId);
-        setDropIsMove(false);
+      // External drops: only highlight if the category declares it
+      // accepts at least one of the MIME types in this drag. Without
+      // this check both sections highlight for any device-item drag
+      // even though only the matching section actually accepts the
+      // drop — operator sees two glowing targets and only one works.
+      // Categories that don't declare `acceptedDropMimeTypes` fall
+      // back to the legacy "accept anything" behavior so non-Roland
+      // editors (akai-s3k, etc.) aren't broken by this guard.
+      if (!onExternalDrop) return;
+      const category = plugin.categories.find((c) => c.categoryId === categoryId);
+      const accepted = category?.acceptedDropMimeTypes;
+      if (accepted && accepted.length > 0) {
+        const types = e.dataTransfer.types;
+        const matched = accepted.some((mime) => types.includes(mime));
+        if (!matched) return;
+      } else if (e.dataTransfer.types.length === 0) {
+        return;
       }
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+      setDropTargetCategory(categoryId);
+      setDropIsMove(false);
     },
-    [onExternalDrop],
+    [onExternalDrop, plugin.categories],
   );
 
   const handleSectionDragLeave = useCallback(
@@ -685,7 +709,13 @@ export function PluginLibraryBrowser({
               name: payload.nodeName,
               type: payload.nodeType,
               children: [],
-              meta: { path: payload.sourcePath },
+              // Preserve the original node's meta (carries `fileName` /
+              // `directoryName` for `getNodeName`) so move handlers
+              // resolve the on-disk slug rather than the display name.
+              // Without the spread, any item whose YAML `name` differs
+              // from its directory slug fails with "file or directory
+              // could not be found." Re-discovered by D-LIB-22.
+              meta: { ...payload.meta, path: payload.sourcePath },
             }, []);
           }
         }
@@ -815,10 +845,21 @@ export function PluginLibraryBrowser({
           </div>
         )}
 
-        {!loading && libraryHandle && (
-          <div className="ac-plugin-library-browser-sections">
-            {headerSections}
-            {plugin.categories.map((category) => (
+        {!loading && libraryHandle && (() => {
+          // Scope-grouping: render two visually-distinct bands so the
+          // operator immediately sees which categories travel with
+          // the connected device (`library/<device>/<category>/`) vs
+          // which survive an editor switch (`library/common/<category>/`).
+          // Categories opt in via `scope: 'device' | 'common'`; default
+          // is 'device' so existing factories without the field stay
+          // under the device band.
+          const deviceCategories = plugin.categories.filter(
+            (c) => (c.scope ?? 'device') === 'device',
+          );
+          const commonCategories = plugin.categories.filter(
+            (c) => c.scope === 'common',
+          );
+          const renderCategorySection = (category: typeof plugin.categories[number]) => (
               <TreeSection
                 key={category.categoryId}
                 data-testid={`library-${category.categoryId}-section`}
@@ -888,13 +929,26 @@ export function PluginLibraryBrowser({
                       e.dataTransfer.dropEffect = 'move';
                       return true;
                     }
-                    // Accept external drops (disk items, OS files)
-                    if (onExternalDrop && e.dataTransfer.types.length > 0) {
-                      e.preventDefault();
-                      e.dataTransfer.dropEffect = 'copy';
-                      return true;
+                    // External drops (disk items, device-memory items):
+                    // only accept the hover if the category declares it
+                    // can take this MIME. Without the check, hovering a
+                    // tone drag over a folder INSIDE the patches section
+                    // still glows the folder even though the actual drop
+                    // gets rejected by `handleExternalDrop`'s category
+                    // gate — operator sees a valid-looking drop target
+                    // that silently does nothing. Same shape as the
+                    // section-level gate in `handleSectionDragOver`.
+                    if (!onExternalDrop) return false;
+                    const accepted = category.acceptedDropMimeTypes;
+                    if (accepted && accepted.length > 0) {
+                      const matched = accepted.some((mime) => e.dataTransfer.types.includes(mime));
+                      if (!matched) return false;
+                    } else if (e.dataTransfer.types.length === 0) {
+                      return false;
                     }
-                    return false;
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = 'copy';
+                    return true;
                   },
                   onTreeDrop: (node, e) => {
                     setDropTargetCategory(null);
@@ -922,7 +976,9 @@ export function PluginLibraryBrowser({
                             name: payload.nodeName,
                             type: payload.nodeType,
                             children: [],
-                            meta: { path: payload.sourcePath },
+                            // See the root-target equivalent above for
+                            // why payload.meta must be spread here.
+                            meta: { ...payload.meta, path: payload.sourcePath },
                           }, targetPath);
                         }
                       }
@@ -949,9 +1005,29 @@ export function PluginLibraryBrowser({
                   createCategoryCallbacks(category.categoryId),
                 )}
               />
-            ))}
-          </div>
-        )}
+          );
+          return (
+            <div className="ac-plugin-library-browser-sections">
+              {(deviceCategories.length > 0 || headerSections) && (
+                <div className="ac-plib-group-head" data-scope="device">
+                  <span className="ac-plib-group-eyebrow">
+                    Device <span className="ac-plib-group-eyebrow-sep">·</span> {plugin.deviceName}
+                  </span>
+                  <span className="ac-plib-group-rule" aria-hidden="true" />
+                </div>
+              )}
+              {headerSections}
+              {deviceCategories.map(renderCategorySection)}
+              {commonCategories.length > 0 && (
+                <div className="ac-plib-group-head" data-scope="common">
+                  <span className="ac-plib-group-eyebrow">Common Library</span>
+                  <span className="ac-plib-group-rule" aria-hidden="true" />
+                </div>
+              )}
+              {commonCategories.map(renderCategorySection)}
+            </div>
+          );
+        })()}
 
         {operationProgress && (
           <div className="ac-plugin-library-browser-progress">

--- a/modules/editor-core/src/components/library/SteppedProgressDrawer.tsx
+++ b/modules/editor-core/src/components/library/SteppedProgressDrawer.tsx
@@ -62,7 +62,7 @@ export interface SteppedProgressDrawerProps {
 // Step icons
 // =========================================================================
 
-function StepIcon({ status }: { status: StepStatus }): JSX.Element {
+export function StepIcon({ status }: { status: StepStatus }): JSX.Element {
   switch (status) {
     case 'pending':
       return (
@@ -106,7 +106,7 @@ function StepIcon({ status }: { status: StepStatus }): JSX.Element {
 // Step row
 // =========================================================================
 
-function StepRow({ step }: { step: ProgressStep }): JSX.Element {
+export function StepRow({ step }: { step: ProgressStep }): JSX.Element {
   return (
     <div className={`ac-step-row ac-step-row--${step.status}`}>
       <StepIcon status={step.status} />

--- a/modules/editor-core/src/components/library/TreeIcons.tsx
+++ b/modules/editor-core/src/components/library/TreeIcons.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { AcChevron } from '../AcChevron';
 
 export function FolderIcon({ isOpen }: { isOpen: boolean }): JSX.Element {
   return (
@@ -32,15 +33,15 @@ export function FolderIcon({ isOpen }: { isOpen: boolean }): JSX.Element {
   );
 }
 
+/**
+ * Legacy alias for the AcChevron primitive. New code should import
+ * AcChevron from '@/components' directly; this re-export exists so the
+ * old `ChevronIcon` callsites continue to compile without code churn.
+ * All chevron sizing/color is owned by the AcChevron component — this
+ * wrapper does not add or override any prop.
+ */
 export function ChevronIcon({ isExpanded }: { isExpanded: boolean }): JSX.Element {
-  // Unicode glyph swap (▾ / ▸) — same chevron vocabulary as
-  // `.ac-list-bank-chevron` and `.ac-device-memory-section-eyebrow-chevron`
-  // so the tree control reads as part of the same family.
-  return (
-    <span className="ac-tree-chevron" aria-hidden="true">
-      {isExpanded ? '▾' : '▸'}
-    </span>
-  );
+  return <AcChevron expanded={isExpanded} />;
 }
 
 export function AudioFileIcon(): JSX.Element {

--- a/modules/editor-core/src/components/library/TreeSection.tsx
+++ b/modules/editor-core/src/components/library/TreeSection.tsx
@@ -10,7 +10,8 @@
  * Device-agnostic — consumers provide node data and capability objects.
  */
 
-import React from 'react';
+import React, { useState } from 'react';
+import { AcChevron } from '../AcChevron';
 import { TreeView, type TreeNode } from './TreeView';
 import type {
   TreeSelectionCapability,
@@ -98,9 +99,17 @@ export function TreeSection({
   dropMessage,
   headerActions,
 }: TreeSectionProps): JSX.Element {
+  // Sections default to expanded. Collapse state is local to the
+  // section instance so each behaves independently. Auto-expand on
+  // drag-over so the operator can drop into a collapsed section
+  // without first clicking to open it.
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const expanded = !isCollapsed || !!isDragOver;
+
   const sectionClasses = [
     'ac-tree-section',
     isDragOver ? 'ac-tree-section--drag-over' : '',
+    expanded ? '' : 'ac-tree-section--collapsed',
   ].filter(Boolean).join(' ');
 
   return (
@@ -112,10 +121,22 @@ export function TreeSection({
       onDrop={onDrop}
       data-category={category}
       data-testid={testId}
+      data-expanded={expanded}
     >
-      {/* Section header */}
+      {/* Section header — title + chevron toggle the section, header
+          actions sit on the right and intentionally do NOT toggle. */}
       <div className="ac-tree-section-header" data-testid={testId ? `${testId}-header` : undefined}>
-        <span className="ac-tree-section-title">{title}</span>
+        <button
+          type="button"
+          className="ac-tree-section-toggle"
+          onClick={() => setIsCollapsed((prev) => !prev)}
+          aria-expanded={expanded}
+          aria-controls={testId ? `${testId}-content` : undefined}
+          data-testid={testId ? `${testId}-toggle` : undefined}
+        >
+          <AcChevron expanded={expanded} />
+          <span className="ac-tree-section-title">{title}</span>
+        </button>
         {isDragOver && dropMessage && (
           <span className="ac-tree-section-drop-hint">
             &mdash; {dropMessage}
@@ -126,24 +147,27 @@ export function TreeSection({
         )}
       </div>
 
-      {/* Content area */}
-      {nodes.length === 0 && !isDragOver ? (
-        <div className="ac-tree-section-empty">{emptyMessage}</div>
-      ) : (
-        <div data-testid={testId ? `${testId}-content` : undefined}>
-          <TreeView
-            nodes={nodes}
-            expandedIds={expandedIds}
-            onToggleExpand={onToggleExpand}
-            selectedId={selectedId}
-            selectedIds={selectedIds}
-            selection={selection}
-            edit={edit}
-            contextMenu={contextMenu}
-            drag={drag}
-            render={render}
-          />
-        </div>
+      {/* Content area (hidden when the section is collapsed, but the
+          drop zone stays mounted so cross-section drops still land). */}
+      {expanded && (
+        nodes.length === 0 && !isDragOver ? (
+          <div className="ac-tree-section-empty">{emptyMessage}</div>
+        ) : (
+          <div data-testid={testId ? `${testId}-content` : undefined} id={testId ? `${testId}-content` : undefined}>
+            <TreeView
+              nodes={nodes}
+              expandedIds={expandedIds}
+              onToggleExpand={onToggleExpand}
+              selectedId={selectedId}
+              selectedIds={selectedIds}
+              selection={selection}
+              edit={edit}
+              contextMenu={contextMenu}
+              drag={drag}
+              render={render}
+            />
+          </div>
+        )
       )}
 
       {/* Drop zone indicator */}

--- a/modules/editor-core/src/components/library/TreeView.test.tsx
+++ b/modules/editor-core/src/components/library/TreeView.test.tsx
@@ -45,12 +45,17 @@ describe('TreeView', () => {
   });
 
   it('hides children when directory is collapsed', () => {
+    // TreeView mounts children inside `<div class="ac-collapse"
+    // data-expanded="…">` regardless of expansion, so the CSS can
+    // animate the open/close. Verify the collapse wrapper reports
+    // collapsed; do not assert child text absence (it's in the DOM,
+    // just hidden via CSS).
     const expanded = new Set<string>();
     const html = renderToStaticMarkup(
       <TreeView nodes={sampleTree} expandedIds={expanded} />,
     );
     expect(html).toContain('Samples');
-    expect(html).not.toContain('kick.wav');
+    expect(html).toContain('class="ac-collapse" data-expanded="false"');
   });
 
   it('shows empty directory message when expanded directory has no children', () => {
@@ -101,7 +106,11 @@ describe('TreeView', () => {
 
   it('renders chevron for directory nodes', () => {
     const html = renderToStaticMarkup(<TreeView nodes={sampleTree} />);
-    expect(html).toContain('ac-tree-chevron');
+    // The AcChevron primitive renders as `<span class="ac-chevron"
+    // data-expanded="…">` — the wrapping toggle (`.ac-tree-disclosure-btn`)
+    // sits around it. Either marker proves a chevron rendered.
+    expect(html).toContain('ac-chevron');
+    expect(html).toContain('ac-tree-disclosure-btn');
   });
 
   it('renders nested children at depth > 1', () => {

--- a/modules/editor-core/src/components/library/TreeView.tsx
+++ b/modules/editor-core/src/components/library/TreeView.tsx
@@ -207,10 +207,19 @@ function TreeNodeRow({
 
   const handleDragEnter = useCallback((e: React.DragEvent) => {
     if (!isDirectory) return;
+    // Only light up the row if the consumer's onTreeDragOver predicate
+    // says it would accept the drop. Without this guard, dragenter
+    // ALWAYS toggles the highlight regardless of MIME-type acceptance
+    // — so a tone dragged over a patches-section folder still glows
+    // even after onTreeDragOver correctly rejects the drop. Consumers
+    // without an onTreeDragOver fall back to legacy "highlight any
+    // dragenter" behavior so non-Roland editors aren't affected.
+    const accepted = drag?.onTreeDragOver ? drag.onTreeDragOver(node, e) : true;
+    if (!accepted) return;
     e.preventDefault();
     e.stopPropagation();
     setIsDragOver(true);
-  }, [isDirectory]);
+  }, [node, isDirectory, drag]);
 
   const handleDragLeave = useCallback((e: React.DragEvent) => {
     if (!isDirectory) return;
@@ -265,6 +274,7 @@ function TreeNodeRow({
         className={`ac-tree-node ${stateClass}${isEditing ? ' ac-tree-node--editing' : ''}${isDraggable && !isEditing ? ' ac-tree-node--draggable' : ''}`}
         style={{ paddingLeft }}
         data-testid={testId}
+        data-kind={isDirectory ? 'folder' : 'item'}
         onClick={handleClick}
         onDoubleClick={canRename ? handleDoubleClick : undefined}
         onContextMenu={contextMenu ? handleContextMenu : undefined}
@@ -281,7 +291,7 @@ function TreeNodeRow({
       >
         {(isDirectory || hasChildren) && (
           <span
-            className="ac-tree-chevron-btn"
+            className="ac-tree-disclosure-btn"
             onClick={(e) => { e.stopPropagation(); onToggleExpand(node.id); }}
           >
             <ChevronIcon isExpanded={isExpanded} />

--- a/modules/editor-core/src/components/library/index.ts
+++ b/modules/editor-core/src/components/library/index.ts
@@ -95,6 +95,8 @@ export { LoadingBar } from './LoadingBar';
 export { SlideDrawer, type SlideDrawerProps } from './SlideDrawer';
 export {
   SteppedProgressDrawer,
+  StepRow,
+  StepIcon,
   type SteppedProgressDrawerProps,
   type ProgressStep,
   type StepStatus,

--- a/modules/editor-core/src/components/library/plugins/types.ts
+++ b/modules/editor-core/src/components/library/plugins/types.ts
@@ -164,6 +164,17 @@ export interface CategoryPlugin {
 
   /** Whether this category is read-only (no modifications allowed) */
   isReadOnly?: boolean;
+
+  /**
+   * Storage scope for this category. Drives the library tree's group
+   * header rendering: device-scoped categories (Sets, Tones, Patches —
+   * stored under `library/<device>/<category>/`) sit under a
+   * 'DEVICE — <deviceName>' band; common-scoped categories (Samples,
+   * Programs — stored under `library/common/<category>/`) sit under a
+   * 'COMMON LIBRARY' band so the operator immediately sees what
+   * survives an editor switch and what doesn't. Default: 'device'.
+   */
+  scope?: 'device' | 'common';
 }
 
 // =========================================================================

--- a/modules/editor-core/src/design/chevron-primitives.css
+++ b/modules/editor-core/src/design/chevron-primitives.css
@@ -1,0 +1,38 @@
+/**
+ * Chevron primitive — the ONLY chevron declaration anywhere in the
+ * editor's CSS. Owns size, color, line-height, transition.
+ *
+ * Consumers MUST render the chevron via the AcChevron React component
+ * (editor-core/src/components/AcChevron.tsx), which emits
+ * `<span class="ac-chevron" data-expanded="…">`. The pre-commit gate
+ * (`tools/check-chevron-sizing.sh`) fails the build if any other CSS
+ * file declares a class containing the substring "chevron", so the
+ * design surface is structurally one-class-only.
+ *
+ * Background: the prior architecture had four hand-coded chevron CSS
+ * classes (`.ac-list-bank-chevron`, `.ac-tree-chevron`,
+ * `.ac-tree-chevron-btn`, `.ac-device-memory-section-eyebrow-chevron`)
+ * that "agreed" by convention until one drifted to 1rem in May 2026.
+ * The drift was invisible to the prior allow-list gate (which gated
+ * by class name, not by value), so the divergence shipped. Replacing
+ * the four classes with this single primitive + a React component +
+ * a no-chevron-elsewhere gate makes drift structurally impossible
+ * without consciously editing this file.
+ *
+ * Target-size baseline: 1.1rem ≈ 17.6px glyph in a 1.1rem square,
+ * which combined with the wrapping toggle's padding clears WCAG AA
+ * target-size floors. Don't shrink this.
+ */
+
+.ac-chevron {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  color: var(--ac-color-accent);
+  flex-shrink: 0;
+  transition: transform var(--ac-duration-fast) var(--ac-easing-default);
+}

--- a/modules/editor-core/src/design/library.css
+++ b/modules/editor-core/src/design/library.css
@@ -88,6 +88,44 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  font-family: var(--ac-font-body);
+  font-size: var(--ac-text-sm);
+  color: var(--ac-color-text);
+}
+
+/* v3 folder rows: Departure Mono UPPERCASE so the hierarchy ladder
+   reads SECTION (eyebrow) → FOLDER (display caps) → ITEM (body sans)
+   without indentation. Pairs with the .ac-tree-item-tag rule below
+   which gives non-folder rows a small mono lead-in tag instead of
+   a per-kind SVG icon (operator-approved 2026-05-21). */
+.ac-tree-node[data-kind="folder"] .ac-tree-node-name {
+  font-family: var(--ac-font-display);
+  font-weight: var(--ac-font-weight-normal);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ac-color-text);
+}
+
+/* Single-letter mono lead-in tag rendered by item-type plugins in
+   place of an SVG icon. Same width as the folder icon column so
+   folder + item rows align vertically. */
+.ac-tree-item-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  font-family: var(--ac-font-display);
+  font-size: var(--ac-text-eyebrow);
+  font-weight: var(--ac-font-weight-normal);
+  letter-spacing: var(--ac-tracking-eyebrow);
+  text-transform: uppercase;
+  color: color-mix(in srgb, var(--ac-color-text-muted) 80%, transparent);
+  flex-shrink: 0;
+}
+
+.ac-tree-node--selected .ac-tree-item-tag {
+  color: var(--ac-color-accent);
 }
 
 /* Trailing metadata next to a tree-node name (e.g. "8 tones" on a
@@ -100,12 +138,17 @@
   flex-shrink: 0;
 }
 
-.ac-tree-chevron-btn {
+/* Disclosure-toggle button — wraps the AcChevron glyph in a tree row.
+   The button has no own size: the AcChevron child (declared in
+   chevron-primitives.css) is the sole authority on the chevron's box.
+   Renamed from `.ac-tree-chevron-btn` 2026-05-21 when the chevron
+   pathology was closed; the word "chevron" cannot appear in any class
+   name outside chevron-primitives.css, so this wrapper is named after
+   its role (a disclosure-toggle button), not after its child glyph. */
+.ac-tree-disclosure-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 1.1rem;
-  height: 1.1rem;
   padding: 0;
   margin-left: -2px;
   background: transparent;
@@ -113,21 +156,6 @@
   cursor: pointer;
   flex-shrink: 0;
   color: var(--ac-color-accent);
-}
-
-/* Unicode glyph chevron (▾ / ▸) sized to match .ac-list-bank-chevron
-   so the tree, the list-bank header, and the device-memory section
-   eyebrow all read as one chevron vocabulary. */
-.ac-tree-chevron {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.1rem;
-  height: 1.1rem;
-  font-size: 1.1rem;
-  line-height: 1;
-  color: var(--ac-color-accent);
-  flex-shrink: 0;
 }
 
 .ac-tree-icon {
@@ -295,8 +323,11 @@
   background: color-mix(in srgb, var(--ac-color-accent) 10%, transparent);
 }
 
-/* Sticky section header — same shape as .ac-list-bank-header: blurred
-   eyebrow strip with backdrop-filter, accent-color cues. */
+/* v3 inset section band — section headers sit inside a hairline-bordered
+   strip with a subtle bg darken so each library section reads as its own
+   sub-panel without indentation. Matches the typography-only hierarchy
+   spec (operator-approved 2026-05-21). Still sticky so the section title
+   stays visible as the body scrolls. */
 .ac-tree-section-header {
   position: sticky;
   top: 0;
@@ -305,9 +336,10 @@
   align-items: center;
   gap: var(--ac-space-2);
   padding: var(--ac-space-2) var(--ac-space-3);
-  background: color-mix(in srgb, var(--ac-color-surface-canvas) 92%, transparent);
+  background: color-mix(in srgb, var(--ac-color-surface-canvas) 60%, transparent);
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  border-top: var(--ac-rule-hairline) solid var(--ac-color-border-subtle);
   border-bottom: var(--ac-rule-hairline) solid var(--ac-color-border-subtle);
 }
 
@@ -318,6 +350,44 @@
   text-transform: uppercase;
   letter-spacing: var(--ac-tracking-eyebrow);
   color: var(--ac-color-text-muted);
+}
+
+/* Section header collapse toggle — chevron + title in a single
+   click target. Style mirrors `.ac-list-bank-toggle` so a library
+   section reads as a peer of a device-memory bank row. */
+.ac-tree-section-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ac-space-2);
+  padding: 0;
+  border: none;
+  background: none;
+  color: inherit;
+  cursor: pointer;
+  font: inherit;
+}
+
+.ac-tree-section-toggle:hover .ac-tree-section-title {
+  color: var(--ac-color-text-primary);
+}
+
+.ac-tree-section-toggle:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--ac-color-accent) 55%, transparent);
+  outline-offset: 2px;
+  border-radius: var(--ac-radius-sm);
+}
+
+/* NOTE: the disclosure glyph is rendered via the AcChevron component
+   (editor-core/src/components/AcChevron.tsx). Its sole CSS rule lives
+   in chevron-primitives.css. Do not declare a chevron-named class
+   anywhere else — the pre-commit gate (tools/check-chevron-sizing.sh)
+   fails the build if you do. See .claude/rules/chevron-sizing.md. */
+
+/* Collapsed-state border: drop the bottom hairline so a stack of
+   collapsed sections reads as a single condensed list rather than
+   a thick separator pile. */
+.ac-tree-section--collapsed > .ac-tree-section-header {
+  border-bottom-color: transparent;
 }
 
 .ac-tree-section-drop-hint {
@@ -914,12 +984,115 @@
   border-bottom: 1px solid var(--ac-color-border-subtle);
 }
 
+/* Library tree scroll container — adopts the same overlay-scrollbar
+   recipe as `.ac-list-scroll` (list-primitives.css) so the library
+   tree matches the patches / tones list chrome: hidden native
+   scrollbar (no layout-shifting gutter), thin webkit overlay thumb,
+   subtle bottom-edge fade. The recipe is duplicated here rather
+   than re-using `.ac-list-scroll` as a sibling class because this
+   container has its own additional layout (flex: 1 + min-height: 0)
+   that the list shell doesn't need. Promote both to a shared
+   `.ac-overlay-scroll` primitive once a third container needs it. */
 .ac-plugin-library-browser-sections {
   flex: 1;
   min-height: 0;
-  overflow-y: auto;
-  scrollbar-width: thin;
-  scrollbar-gutter: stable;
+  overflow-y: scroll;
+  scrollbar-width: none;
+  scrollbar-gutter: auto;
+  mask-image: linear-gradient(
+    to bottom,
+    black 0,
+    black calc(100% - 1.25rem),
+    color-mix(in srgb, black 60%, transparent) 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    black 0,
+    black calc(100% - 1.25rem),
+    color-mix(in srgb, black 60%, transparent) 100%
+  );
+}
+
+.ac-plugin-library-browser-sections::-webkit-scrollbar {
+  width: 8px;
+  background: transparent;
+}
+
+.ac-plugin-library-browser-sections::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.ac-plugin-library-browser-sections::-webkit-scrollbar-thumb {
+  background-color: color-mix(in srgb, var(--ac-color-text-muted) 35%, transparent);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: padding-box;
+  transition: background-color var(--ac-duration-fast) var(--ac-easing-default);
+}
+
+.ac-plugin-library-browser-sections::-webkit-scrollbar-thumb:hover {
+  background-color: color-mix(in srgb, var(--ac-color-text-muted) 70%, transparent);
+  background-clip: padding-box;
+}
+
+/* =========================================================================
+   Scope group bands — device vs common library
+   -------------------------------------------------------------------------
+   The library tree groups categories by storage scope:
+     device  → library/<device>/<category>/  (Sets, Tones, Patches)
+     common  → library/common/<category>/    (Samples, Programs)
+   Two visually-distinct bands above each group make the split
+   obvious so the operator immediately sees what an editor switch
+   keeps vs replaces.
+
+   The bands use v3 typography (Departure Mono + ac-tracking-eyebrow
+   + ac-color-accent rule), matching the .ac-page-title-row rhythm
+   used elsewhere — these read as peer headers, not as small chrome.
+   ========================================================================= */
+.ac-plib-group-head {
+  display: flex;
+  align-items: center;
+  gap: var(--ac-space-3);
+  padding: var(--ac-space-3) var(--ac-space-1) var(--ac-space-2);
+  /* First group sits flush to the top of the sections column; later
+     groups bump above by a single space for breathing room. */
+}
+
+.ac-plib-group-head + .ac-plib-group-head,
+.ac-tree-section + .ac-plib-group-head {
+  margin-top: var(--ac-space-4);
+}
+
+.ac-plib-group-eyebrow {
+  font-family: var(--ac-font-display);
+  font-size: var(--ac-text-eyebrow);
+  font-weight: var(--ac-font-weight-medium, 500);
+  letter-spacing: var(--ac-tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ac-color-text);
+  white-space: nowrap;
+}
+
+.ac-plib-group-eyebrow-sep {
+  color: var(--ac-color-text-muted);
+  margin-inline: 0.15em;
+}
+
+.ac-plib-group-rule {
+  flex: 1 1 auto;
+  height: var(--ac-rule-hairline, 1px);
+  background: color-mix(in srgb, var(--ac-color-accent) 55%, transparent);
+}
+
+/* Common-area group: differentiate the rule color so the operator
+   can tell the two bands apart at a glance even when "Device" /
+   "Common" labels read identically in width. */
+.ac-plib-group-head[data-scope="common"] .ac-plib-group-eyebrow {
+  color: var(--ac-color-text-muted);
+}
+
+.ac-plib-group-head[data-scope="common"] .ac-plib-group-rule {
+  background: color-mix(in srgb, var(--ac-color-text-muted) 35%, transparent);
 }
 
 .ac-plugin-library-browser-toolbar {
@@ -1068,9 +1241,18 @@
   flex-shrink: 0;
 }
 
+/* v3 column-header title — mirrors `.ac-preview-pane-head-title`
+   (Device Memory header) so every library-column header reads in
+   the same Departure Mono display vocabulary. Previously this used
+   body-font semibold which made the Library and Preview column
+   titles look like buttons next to Device Memory's display heading. */
 .ac-panel-header-title {
-  font-size: var(--ac-text-sm);
-  font-weight: var(--ac-font-weight-semibold);
+  margin: 0;
+  font-family: var(--ac-font-display);
+  font-weight: var(--ac-font-weight-normal);
+  font-size: var(--ac-text-md);
+  letter-spacing: var(--ac-tracking-display);
+  line-height: 1.2;
   color: var(--ac-color-text-primary);
 }
 

--- a/modules/editor-core/src/design/list-primitives.css
+++ b/modules/editor-core/src/design/list-primitives.css
@@ -200,21 +200,9 @@
   outline-offset: 2px;
 }
 
-/* Chevron — sized so the affordance is obvious at the header's
-   eyebrow-scale font. 1.1rem gives ~17.6px which clears AA target-size
-   floors when combined with the button's padding (total hit area
-   ≈28x28px). */
-.ac-list-bank-chevron {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1.1rem;
-  height: 1.1rem;
-  font-size: 1.1rem;
-  line-height: 1;
-  color: var(--ac-color-accent);
-  transition: transform var(--ac-duration-fast) var(--ac-easing-default);
-}
+/* (Bank-header chevron lives in chevron-primitives.css as the single
+   `.ac-chevron` primitive, rendered by the AcChevron component. No
+   per-context chevron class is declared here.) */
 
 /* Right-side group inside the bank header: slot-range readout plus the
    per-bank reload icon-button. Wrapped in a flex container so the

--- a/modules/editor-core/src/design/overlay-primitives.css
+++ b/modules/editor-core/src/design/overlay-primitives.css
@@ -106,11 +106,14 @@
   right: 0;
   bottom: 0;
   z-index: 101;
-  width: 24rem;
+  /* v3: wider than the v2 24rem default so export/move/save forms
+     don't feel cramped. Body content reads cleanly at ~28rem; the
+     90vw cap still keeps it sane on small viewports. */
+  width: 28rem;
   max-width: 90vw;
   background: var(--ac-color-surface-panel);
-  border-left: 1px solid var(--ac-color-border-subtle);
-  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.3);
+  border-left: 1px solid color-mix(in srgb, var(--ac-color-accent) 28%, transparent);
+  box-shadow: -12px 0 36px rgba(0, 0, 0, 0.45);
   display: flex;
   flex-direction: column;
   transform: translateX(0);
@@ -121,19 +124,27 @@
   transform: translateX(100%);
 }
 
+/* v3 drawer header — mirrors the `.ac-page-title-row` rhythm
+   (Departure Mono display heading + accent hairline rule) so a
+   drawer reads as a peer surface to a page, not a generic modal. */
 .ac-drawer-header {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
-  padding: var(--ac-space-3) var(--ac-space-4);
-  border-bottom: 1px solid var(--ac-color-border-subtle);
+  padding: var(--ac-space-5) var(--ac-space-5) var(--ac-space-3);
+  border-bottom: var(--ac-rule-medium, 2px) solid
+    color-mix(in srgb, var(--ac-color-accent) 55%, transparent);
   flex-shrink: 0;
 }
 
 .ac-drawer-title {
-  font-size: 1rem;
-  font-weight: var(--ac-font-weight-semibold);
-  color: var(--ac-color-text-primary);
+  margin: 0;
+  font-family: var(--ac-font-display);
+  font-size: var(--ac-text-lg);
+  font-weight: var(--ac-font-weight-medium, 500);
+  letter-spacing: var(--ac-tracking-display);
+  text-transform: uppercase;
+  color: var(--ac-color-text-primary, var(--ac-color-text));
 }
 
 .ac-drawer-close {

--- a/modules/editor-core/src/design/primitives.css
+++ b/modules/editor-core/src/design/primitives.css
@@ -124,18 +124,29 @@
   accent-color: var(--ac-color-accent);
 }
 
+/*
+ * v3 button vocabulary: Departure Mono uppercase + eyebrow tracking,
+ * matching the page-title / detail-eyebrow / drawer-title rhythm. The
+ * slightly smaller `--ac-text-sm` text-size and the bumped horizontal
+ * padding compensate for the wider monospace glyphs so labels stay
+ * proportionate to the controls they sit beside.
+ */
 .ac-btn {
   display: inline-flex;
   align-items: center;
-  gap: 0.375rem;
+  justify-content: center;
+  gap: 0.5rem;
   white-space: nowrap;
   border-radius: var(--ac-radius-md);
   border: 1px solid var(--ac-color-border-subtle);
   background: color-mix(in srgb, var(--ac-color-surface-panel) 94%, transparent);
   color: var(--ac-color-text-primary);
-  padding: 0.625rem 0.75rem;
-  font-size: var(--ac-text-md);
-  font-weight: var(--ac-font-weight-semibold);
+  padding: 0.5rem 0.95rem;
+  font-family: var(--ac-font-display);
+  font-size: var(--ac-text-sm);
+  font-weight: 400;
+  letter-spacing: var(--ac-tracking-eyebrow);
+  text-transform: uppercase;
   cursor: pointer;
   transition:
     filter var(--ac-duration-fast) var(--ac-easing-default),
@@ -170,7 +181,7 @@
 
 .ac-btn-sm {
   padding: 0.375rem 0.75rem;
-  font-size: var(--ac-text-sm);
+  font-size: var(--ac-text-eyebrow);
 }
 
 .ac-btn-success {

--- a/modules/editor-core/src/design/styles.css
+++ b/modules/editor-core/src/design/styles.css
@@ -35,3 +35,4 @@
 @import './list-primitives.css';
 @import './loop-editor-primitives.css';
 @import './library.css';
+@import './chevron-primitives.css';

--- a/modules/editor-core/src/design/tokens.css
+++ b/modules/editor-core/src/design/tokens.css
@@ -174,6 +174,27 @@
   --ac-color-selected: var(--ac-roland-primary);
 }
 
+/* S-550 shares the S-330 surface palette: same Roland chassis lineage,
+   same v3 visual target. Without this block the s550 route falls
+   through to the unscoped :root defaults where surface-canvas and
+   surface-panel are nearly identical (#0f172a / #111827) — so the
+   library + device-memory + preview columns lose their lifted card
+   appearance and visually merge with the page canvas. Added 2026-05-21
+   after operator caught the divergence between s330 (lifted panels in
+   screenshots) and s550 (flat). */
+:root[data-editor='s550'] {
+  --ac-color-surface-canvas: #0f172a;
+  --ac-color-surface-panel: #1e293b;
+  --ac-color-border-subtle: #334155;
+  --ac-color-text-primary: #f1f5f9;
+  --ac-color-text-muted: #94a3b8;
+  --ac-color-accent: var(--ac-roland-primary);
+  --ac-color-success: #22c55e;
+  --ac-color-warning: var(--ac-roland-secondary);
+  --ac-color-danger: #fb7185;
+  --ac-color-selected: var(--ac-roland-primary);
+}
+
 :root[data-editor='d110'] {
   --ac-color-surface-canvas: #111827;
   --ac-color-surface-panel: #1f2937;

--- a/modules/editor-core/src/hooks/useLibraryOperations.ts
+++ b/modules/editor-core/src/hooks/useLibraryOperations.ts
@@ -174,6 +174,17 @@ export interface LibraryOperationsStrategy {
   deleteItem(categoryId: string, node: TreeNode): Promise<StrategyResult>;
   /** Rename a device-specific item. Return handled:true if handled, handled:false to use common-area rename. */
   renameItem(categoryId: string, node: TreeNode, newName: string): Promise<StrategyResult>;
+  /**
+   * Move a device-specific item to a new target path within the same
+   * category. Return handled:true if handled, handled:false to fall back
+   * to the common-area `moveItem` (which only knows the samples root).
+   * Optional — strategies that don't implement it get the common-area
+   * fallback, but device-specific categories whose files don't live in
+   * `library/common/samples/` MUST provide this to avoid "file or
+   * directory not found" errors when the common-area fallback resolves
+   * against the wrong root.
+   */
+  moveItem?(categoryId: string, node: TreeNode, targetPath: string[]): Promise<StrategyResult>;
   /** Handle a context menu action. Required -- every editor must route actions. */
   handleContextMenuAction(categoryId: string, actionId: string, node: TreeNode): StrategyResult;
 }
@@ -325,6 +336,18 @@ export function useLibraryOperations(
       const name = getNodeName(node);
       const sourcePath = getNodePath(node);
       try {
+        // Strategy first: device-specific categories (Roland's
+        // library/<device>/<category>/, Akai's program tree) own the
+        // path layout and must handle the move themselves. The
+        // common-area `moveItem` only knows `library/common/samples/`
+        // and will throw "not found" against any other root.
+        if (strategy?.moveItem) {
+          const result = await strategy.moveItem(categoryId, node, targetPath);
+          if (result.handled) {
+            onRefresh();
+            return;
+          }
+        }
         if (PROGRAM_CATEGORIES.has(categoryId)) {
           const srcParent = await getCategoryDir(libraryRoot, categoryId, sourcePath);
           const destParent = await getCategoryDir(libraryRoot, categoryId, targetPath);
@@ -337,7 +360,7 @@ export function useLibraryOperations(
         onError(`Failed to move "${name}": ${err instanceof Error ? err.message : String(err)}`);
       }
     },
-    [libraryRoot, onRefresh, onError],
+    [libraryRoot, strategy, onRefresh, onError],
   );
 
   const onRename = useCallback(
@@ -486,6 +509,15 @@ export function useLibraryOperations(
       const errors: string[] = [];
       for (const node of nodes) {
         try {
+          // Same strategy-first routing as the single-item `onMove`.
+          // Without this, device-specific categories whose files don't
+          // live in `library/common/samples/` fall through to the
+          // common-area `moveItem` per-item and emit one
+          // "file or directory not found" per node.
+          if (strategy?.moveItem) {
+            const result = await strategy.moveItem(categoryId, node, targetPath);
+            if (result.handled) continue;
+          }
           const name = getNodeName(node);
           const sourcePath = getNodePath(node);
           if (PROGRAM_CATEGORIES.has(categoryId)) {
@@ -504,7 +536,7 @@ export function useLibraryOperations(
         onError(`Failed to move ${errors.length} item(s):\n${errors.join('\n')}`);
       }
     },
-    [libraryRoot, onRefresh, onError],
+    [libraryRoot, strategy, onRefresh, onError],
   );
 
   return {

--- a/modules/editor-core/src/plugins/common-area/categories.tsx
+++ b/modules/editor-core/src/plugins/common-area/categories.tsx
@@ -94,6 +94,7 @@ export function createCommonSamplesCategory(
   return {
     categoryId,
     title: 'Samples',
+    scope: 'common',
     itemTypes: {
       sample: createCommonSampleItemType(supportedActions),
     },
@@ -127,6 +128,7 @@ export function createCommonProgramsCategory(
   return {
     categoryId,
     title: 'Programs',
+    scope: 'common',
     itemTypes: {
       program: createCommonProgramItemType(supportedActions),
     },

--- a/modules/editor-core/src/plugins/common-area/item-types.tsx
+++ b/modules/editor-core/src/plugins/common-area/item-types.tsx
@@ -9,7 +9,15 @@
 
 import type { ItemTypePlugin, PluginContextMenuAction } from '@/components/library/plugins/types';
 import type { TransferActionId } from '@/hooks/useLibraryOperations';
-import { SampleIcon, ProgramIcon } from '@/plugins/common-area/icons';
+
+/**
+ * Single-letter mono lead-in tag used in place of a per-kind icon —
+ * see roland-sxx0-editor/src/plugins/shared/item-types.tsx for the
+ * canonical comment. Items here are common-area (S = sample, K = program-kit).
+ */
+function KindTag({ children }: { children: string }): JSX.Element {
+  return <span className="ac-tree-item-tag" aria-hidden="true">{children}</span>;
+}
 
 // =========================================================================
 // Metadata types
@@ -52,7 +60,7 @@ export function createCommonSampleItemType(
     typeId: 'sample',
     displayName: 'Sample',
 
-    renderIcon: () => <SampleIcon />,
+    renderIcon: () => <KindTag>S</KindTag>,
 
     renderTrailing: (meta) => {
       if (!meta.sliceCount || meta.sliceCount <= 0) return null;
@@ -117,7 +125,7 @@ export function createCommonProgramItemType(
     typeId: 'program',
     displayName: 'Program',
 
-    renderIcon: () => <ProgramIcon />,
+    renderIcon: () => <KindTag>K</KindTag>,
 
     renderTrailing: (meta) => {
       if (!meta.kitCount || meta.kitCount <= 0) return null;

--- a/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { SlideDrawer } from '@audiocontrol/editor-core';
 import { StepLogBody, renderFooter } from './ExportToneDialog';
 import { useStepHistory } from '@/hooks/useStepHistory';
+import { useDeviceConfig } from '@/context/DeviceConfigContext';
 import {
   type OperationState,
   isOperationComplete,
@@ -70,6 +71,7 @@ export function BatchExportDrawer({
   progress,
   error: operationError,
 }: BatchExportDrawerProps): JSX.Element | null {
+  const { deviceName } = useDeviceConfig();
   const [localError, setLocalError] = useState<string | null>(null);
   const [hasStarted, setHasStarted] = useState(false);
 
@@ -156,6 +158,7 @@ export function BatchExportDrawer({
           kind={kind}
           items={items}
           targetPath={targetPath}
+          deviceName={deviceName}
           error={localError}
         />
       )}
@@ -167,10 +170,14 @@ interface BatchFormBodyProps {
   kind: 'tone' | 'patch';
   items: BatchExportItem[];
   targetPath: string[];
+  /** Active device name from useDeviceConfig — routed in instead of
+   *  hardcoded so the eyebrow shows S-330 / S-550 correctly per
+   *  active surface. AUDIT-20260521-02. */
+  deviceName: string;
   error: string | null;
 }
 
-function BatchFormBody({ kind, items, targetPath, error }: BatchFormBodyProps): JSX.Element {
+function BatchFormBody({ kind, items, targetPath, deviceName, error }: BatchFormBodyProps): JSX.Element {
   const eyebrowKindLabel = kind === 'tone' ? 'TONES' : 'PATCHES';
   return (
     <div className="ac-export-form">
@@ -181,7 +188,7 @@ function BatchFormBody({ kind, items, targetPath, error }: BatchFormBodyProps): 
         <span className="ac-detail-eyebrow-sep">·</span>
         <span>LIBRARY</span>
         <span className="ac-detail-eyebrow-sep">·</span>
-        <span>S330</span>
+        <span data-testid="batch-export-device-name">{deviceName.toUpperCase()}</span>
         {targetPath.length > 0 && (
           <>
             <span className="ac-detail-eyebrow-sep">·</span>

--- a/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx
@@ -1,0 +1,193 @@
+/**
+ * Batch Export Drawer (v3)
+ *
+ * Right-edge SlideDrawer that handles multi-item exports from device
+ * memory to library. Drop multi-selected device tones / patches on the
+ * library section → useLibraryExport detects `data.indices` and opens
+ * this drawer instead of the single-item ExportToneDialog /
+ * ExportPatchDialog.
+ *
+ * Idle body: item list (slot + device name) + destination path.
+ * Running body: the same SteppedProgressDrawer step-log that the
+ * single-item flows use — each item becomes one step ("Exporting
+ * <name>"), advanced by `useLibraryExport.handleBatchExport`.
+ *
+ * Reuses `StepLogBody` and `renderFooter` from ExportToneDialog so
+ * the chrome (footer button states, success/error transitions, etc.)
+ * is identical across single and batch flows.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { SlideDrawer } from '@audiocontrol/editor-core';
+import { StepLogBody, renderFooter } from './ExportToneDialog';
+import { useStepHistory } from '@/hooks/useStepHistory';
+import {
+  type OperationState,
+  isOperationComplete,
+} from '@/types/import-operation';
+
+export interface BatchExportItem {
+  /** Device slot index (tone or patch, depending on `kind`). */
+  index: number;
+  /** Display name shown in the item list + carried into the library
+   *  write as the file slug (slugified by exportToneToDirectory /
+   *  exportPatchToDirectory downstream). */
+  name: string;
+  /** Slot label as the device sees it (e.g. "T01", "P15"). Used only
+   *  for the item list — the export itself works from `index`. */
+  slotLabel: string;
+}
+
+export interface BatchExportDrawerProps extends OperationState {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Which kind of item the drawer is exporting. Drives the title +
+   *  the success message. */
+  kind: 'tone' | 'patch';
+  items: BatchExportItem[];
+  /** Library subfolder the batch will land in. Empty array means the
+   *  category root (e.g. tones/ or patches/). Surfaced in the eyebrow
+   *  so the operator confirms the destination before clicking Export. */
+  targetPath: string[];
+  onExport: () => Promise<void>;
+}
+
+export function BatchExportDrawer({
+  open,
+  onOpenChange,
+  kind,
+  items,
+  targetPath,
+  onExport,
+  isOperating,
+  progress,
+  error: operationError,
+}: BatchExportDrawerProps): JSX.Element | null {
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [hasStarted, setHasStarted] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setLocalError(null);
+      setHasStarted(false);
+    }
+  }, [open]);
+
+  const isComplete = isOperationComplete({
+    isOperating,
+    progress,
+    error: operationError,
+  });
+  const effectiveError = localError ?? operationError;
+  const steps = useStepHistory({ progress, isComplete, error: effectiveError });
+
+  const handleExport = useCallback(async () => {
+    setLocalError(null);
+    setHasStarted(true);
+    try {
+      await onExport();
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Batch export failed');
+    }
+  }, [onExport]);
+
+  const handleClose = useCallback(() => {
+    if (isOperating) return;
+    setLocalError(null);
+    onOpenChange(false);
+  }, [isOperating, onOpenChange]);
+
+  if (!open) return null;
+
+  const footer = renderFooter({
+    hasStarted,
+    isComplete,
+    hasError: !!effectiveError,
+    isOperating,
+    canExport: items.length > 0,
+    onCancel: handleClose,
+    onExport: handleExport,
+    onClose: handleClose,
+  });
+
+  const title = kind === 'tone'
+    ? `Export ${items.length} tones to library`
+    : `Export ${items.length} patches to library`;
+
+  const successKindLabel = kind === 'tone' ? 'tones' : 'patches';
+
+  return (
+    <SlideDrawer
+      open={open}
+      title={title}
+      onClose={handleClose}
+      footer={footer}
+    >
+      {hasStarted ? (
+        <StepLogBody
+          steps={steps}
+          isComplete={isComplete}
+          hasError={!!effectiveError}
+          successMessage={`All ${items.length} ${successKindLabel} exported`}
+        />
+      ) : (
+        <BatchFormBody
+          kind={kind}
+          items={items}
+          targetPath={targetPath}
+          error={localError}
+        />
+      )}
+    </SlideDrawer>
+  );
+}
+
+interface BatchFormBodyProps {
+  kind: 'tone' | 'patch';
+  items: BatchExportItem[];
+  targetPath: string[];
+  error: string | null;
+}
+
+function BatchFormBody({ kind, items, targetPath, error }: BatchFormBodyProps): JSX.Element {
+  const eyebrowKindLabel = kind === 'tone' ? 'TONES' : 'PATCHES';
+  return (
+    <div className="ac-export-form">
+      <div className="ac-detail-eyebrow-row" data-testid="batch-export-destination">
+        <span className="ac-detail-eyebrow-accent">{eyebrowKindLabel}</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>{items.length} ITEMS</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>LIBRARY</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>S330</span>
+        {targetPath.length > 0 && (
+          <>
+            <span className="ac-detail-eyebrow-sep">·</span>
+            <span data-testid="batch-export-target-path">{targetPath.join(' / ')}</span>
+          </>
+        )}
+      </div>
+      <div className="ac-page-title-rule" aria-hidden="true" />
+
+      {error && (
+        <p className="ac-export-form-error" role="alert">
+          {error}
+        </p>
+      )}
+
+      <ul className="ac-batch-export-list" data-testid="batch-export-item-list">
+        {items.map((item) => (
+          <li
+            key={item.index}
+            className="ac-batch-export-row"
+            data-testid={`batch-export-item-${item.index}`}
+          >
+            <span className="ac-batch-export-slot">{item.slotLabel}</span>
+            <span className="ac-batch-export-name">{item.name}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/BatchExportDrawer.tsx
@@ -49,6 +49,12 @@ export interface BatchExportDrawerProps extends OperationState {
    *  category root (e.g. tones/ or patches/). Surfaced in the eyebrow
    *  so the operator confirms the destination before clicking Export. */
   targetPath: string[];
+  /** Per-item failure map keyed by step number (1-based). Populated by
+   *  useLibraryExport.handleBatchExport as items fail; passed through
+   *  to useStepHistory so failed rows render with ✗ + the per-item
+   *  error message instead of vanishing into a single top-level error.
+   *  An empty map = all items succeeded. */
+  failures: Map<number, string>;
   onExport: () => Promise<void>;
 }
 
@@ -58,6 +64,7 @@ export function BatchExportDrawer({
   kind,
   items,
   targetPath,
+  failures,
   onExport,
   isOperating,
   progress,
@@ -79,7 +86,12 @@ export function BatchExportDrawer({
     error: operationError,
   });
   const effectiveError = localError ?? operationError;
-  const steps = useStepHistory({ progress, isComplete, error: effectiveError });
+  const steps = useStepHistory({
+    progress,
+    isComplete,
+    error: effectiveError,
+    stepErrors: failures,
+  });
 
   const handleExport = useCallback(async () => {
     setLocalError(null);
@@ -115,6 +127,15 @@ export function BatchExportDrawer({
     : `Export ${items.length} patches to library`;
 
   const successKindLabel = kind === 'tone' ? 'tones' : 'patches';
+  // Distinguish all-success from partial-success in the summary row
+  // beneath the step log. A partial-success batch is still considered
+  // "complete" (not error state — the drawer chrome shows Done, not
+  // Close) but the message accurately reports the count so the
+  // operator doesn't need to count green checks themselves.
+  const successCount = items.length - failures.size;
+  const successMessage = failures.size === 0
+    ? `All ${items.length} ${successKindLabel} exported`
+    : `${successCount} of ${items.length} ${successKindLabel} exported · ${failures.size} failed (see step log)`;
 
   return (
     <SlideDrawer
@@ -128,7 +149,7 @@ export function BatchExportDrawer({
           steps={steps}
           isComplete={isComplete}
           hasError={!!effectiveError}
-          successMessage={`All ${items.length} ${successKindLabel} exported`}
+          successMessage={successMessage}
         />
       ) : (
         <BatchFormBody

--- a/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx
@@ -16,7 +16,7 @@
  * structural parity with the rest of the editor.
  */
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { useDeviceConfig } from '@/context/DeviceConfigContext';
 import type { SamplerTone, SamplerPatch } from '@/core/midi/SamplerClient';
@@ -24,13 +24,20 @@ import { PatchLabel } from '@/components/common/PatchLabel';
 import { isToneEmpty, isPatchEmpty } from '@/lib/slot-allocation';
 import type { LibraryDragPayload } from '@/lib/library-drag-types';
 import { LIBRARY_ITEM_MIME } from '@/lib/library-drag-types';
+import { AcChevron } from '@audiocontrol/editor-core';
 
-/** Data transfer payload for items dragged out of the device. */
+/** Data transfer payload for items dragged out of the device.
+ *  When the operator multi-selects (Ctrl/Shift-click) on the device
+ *  memory panel and drags any selected slot, `indices` is populated
+ *  with the full selection and the consuming side opens a batch
+ *  export drawer instead of the single-item dialog. For single-item
+ *  drags `indices` is absent and `index` is the only slot. */
 export interface DeviceDragData {
   source: 'device';
   type: 'tone' | 'patch';
   index: number;
   name: string;
+  indices?: number[];
 }
 
 /** MIME type for device drag data. */
@@ -94,6 +101,15 @@ export function DeviceMemoryPanel({
   const [isSampleDragOver, setIsSampleDragOver] = useState(false);
   const [collapsedToneBanks, setCollapsedToneBanks] = useState<Set<number>>(() => new Set());
   const [collapsedPatchBanks, setCollapsedPatchBanks] = useState<Set<number>>(() => new Set());
+  // Multi-select sets for batch drag-export. Populated by the click
+  // dispatchers below (ctrl/meta-click toggles membership, shift-click
+  // extends from the anchor, plain click clears). The dragstart
+  // handlers below consult these and emit a batch payload (DeviceDragData
+  // with `indices`) when the dragged slot is part of a >1 selection.
+  const [multiTones, setMultiTones] = useState<Set<number>>(() => new Set());
+  const [multiPatches, setMultiPatches] = useState<Set<number>>(() => new Set());
+  const lastToneAnchorRef = useRef<number | null>(null);
+  const lastPatchAnchorRef = useRef<number | null>(null);
   // Section-level expand/collapse — independent of per-bank collapse.
   // Default: both sections expanded so the layout is 50/50. Toggling a
   // section to collapsed gives the other section the full remaining
@@ -118,27 +134,116 @@ export function DeviceMemoryPanel({
     });
   };
 
+  // ---- Multi-select click dispatchers ---------------------------
+  // Plain click  = page-level select (drives the preview pane) AND
+  //                clear the multi-set.
+  // Ctrl/Meta    = toggle THIS slot in the multi-set; keep the page-
+  //                level anchor where it was; the prior anchor is
+  //                seeded into the set on the first ctrl-toggle so it
+  //                stays highlighted alongside the new selection.
+  // Shift-click  = range select from the last anchor to this slot.
+  // Empty slots never enter the set and never become an anchor.
+  const handleToneClick = useCallback((index: number, e: React.MouseEvent) => {
+    if (!tones[index]) return;
+    if (e.shiftKey && lastToneAnchorRef.current !== null) {
+      const a = Math.min(lastToneAnchorRef.current, index);
+      const b = Math.max(lastToneAnchorRef.current, index);
+      const next = new Set<number>();
+      for (let i = a; i <= b; i += 1) if (tones[i]) next.add(i);
+      setMultiTones(next);
+      return;
+    }
+    if (e.ctrlKey || e.metaKey) {
+      // Capture the prior anchor BEFORE the setMultiTones updater runs.
+      // React batches state updates and runs the updater asynchronously,
+      // so `lastToneAnchorRef.current = index` below would clobber the
+      // ref before the updater reads it — the seed would never fire.
+      const priorAnchor = lastToneAnchorRef.current;
+      setMultiTones((prev) => {
+        const next = new Set(prev);
+        if (next.size === 0 && priorAnchor !== null && priorAnchor !== index) {
+          next.add(priorAnchor);
+        }
+        if (next.has(index)) next.delete(index); else next.add(index);
+        return next;
+      });
+      lastToneAnchorRef.current = index;
+      return;
+    }
+    setMultiTones(new Set());
+    lastToneAnchorRef.current = index;
+    onSelectTone(index);
+  }, [tones, onSelectTone]);
+
+  const handlePatchClick = useCallback((index: number, e: React.MouseEvent) => {
+    if (!patches[index]) return;
+    if (e.shiftKey && lastPatchAnchorRef.current !== null) {
+      const a = Math.min(lastPatchAnchorRef.current, index);
+      const b = Math.max(lastPatchAnchorRef.current, index);
+      const next = new Set<number>();
+      for (let i = a; i <= b; i += 1) if (patches[i]) next.add(i);
+      setMultiPatches(next);
+      return;
+    }
+    if (e.ctrlKey || e.metaKey) {
+      // See handleToneClick — capture the prior anchor before the
+      // setMultiPatches updater runs so the seed sees the *prior*
+      // anchor, not the one being assigned below.
+      const priorAnchor = lastPatchAnchorRef.current;
+      setMultiPatches((prev) => {
+        const next = new Set(prev);
+        if (next.size === 0 && priorAnchor !== null && priorAnchor !== index) {
+          next.add(priorAnchor);
+        }
+        if (next.has(index)) next.delete(index); else next.add(index);
+        return next;
+      });
+      lastPatchAnchorRef.current = index;
+      return;
+    }
+    setMultiPatches(new Set());
+    lastPatchAnchorRef.current = index;
+    onSelectPatch(index);
+  }, [patches, onSelectPatch]);
+
   // ---- Drag handlers --------------------------------------------
   const handleToneDragStart = useCallback(
     (e: React.DragEvent, index: number, tone: SamplerTone) => {
+      // If the dragged slot is part of a multi-select, send the
+      // whole set as a batch; otherwise single-item drag (unchanged).
+      const batch = multiTones.has(index) && multiTones.size > 1
+        ? Array.from(multiTones).sort((a, b) => a - b)
+        : undefined;
       const dragData: DeviceDragData = {
         source: 'device', type: 'tone', index,
         name: tone.name || `Tone ${index + 1}`,
+        ...(batch ? { indices: batch } : {}),
       };
       e.dataTransfer.setData(DEVICE_DRAG_MIME, JSON.stringify(dragData));
+      // Shadow MIME used by section dragover handlers to discriminate
+      // tone vs patch drags WITHOUT having to parse the JSON payload
+      // (which most browsers withhold during dragover for security).
+      // Mirrors the LIBRARY_ITEM_MIME pattern in PluginLibraryBrowser.
+      e.dataTransfer.setData(`${DEVICE_DRAG_MIME}/tone`, '');
       e.dataTransfer.effectAllowed = 'copy';
-    }, [],
+    }, [multiTones],
   );
 
   const handlePatchDragStart = useCallback(
     (e: React.DragEvent, index: number, patch: SamplerPatch) => {
+      const batch = multiPatches.has(index) && multiPatches.size > 1
+        ? Array.from(multiPatches).sort((a, b) => a - b)
+        : undefined;
       const dragData: DeviceDragData = {
         source: 'device', type: 'patch', index,
         name: patch.common.name || `Patch ${index + 1}`,
+        ...(batch ? { indices: batch } : {}),
       };
       e.dataTransfer.setData(DEVICE_DRAG_MIME, JSON.stringify(dragData));
+      // Shadow MIME — see tone-side comment above.
+      e.dataTransfer.setData(`${DEVICE_DRAG_MIME}/patch`, '');
       e.dataTransfer.effectAllowed = 'copy';
-    }, [],
+    }, [multiPatches],
   );
 
   const handleSlotDragOver = useCallback((e: React.DragEvent) => {
@@ -257,9 +362,7 @@ export function DeviceMemoryPanel({
           aria-label={`Toggle bank ${bankIndex + 1}`}
           data-testid={`device-${kind}-bank-toggle-${bankIndex}`}
         >
-          <span className="ac-list-bank-chevron" aria-hidden="true">
-            {isCollapsed ? '▸' : '▾'}
-          </span>
+          <AcChevron expanded={!isCollapsed} />
           <span>Bank {bankIndex + 1}</span>
         </button>
         <span className="ac-list-bank-meta">
@@ -288,6 +391,7 @@ export function DeviceMemoryPanel({
   function renderToneSlot(index: number, bankIndex: number, isBankLoading: boolean): JSX.Element {
     const tone = tones[index];
     const isSelected = selectedType === 'tone' && selectedIndex === index;
+    const isMultiSelected = multiTones.has(index);
     const isLoaded = loadedToneBanks.includes(bankIndex);
     const isDragOver = dragOverToneSlot === index;
     // Mirror ToneList's name-class logic exactly so the typography
@@ -300,9 +404,12 @@ export function DeviceMemoryPanel({
       ? '(loading...)'
       : tone?.name || '';
 
-    const handleClick = (): void => {
+    // Dispatch click through the multi-select handler when a tone is
+    // present (plain/ctrl/shift each have distinct semantics). For
+    // empty rows fall through to the bank loader as before.
+    const handleClick = (e: React.MouseEvent): void => {
       if (tone) {
-        onSelectTone(index);
+        handleToneClick(index, e);
       } else if (!isBankLoading && !isLoaded && onLoadToneBank) {
         onLoadToneBank(bankIndex);
       }
@@ -313,16 +420,22 @@ export function DeviceMemoryPanel({
         key={index}
         role="button"
         tabIndex={isBankLoading ? -1 : 0}
-        aria-selected={isSelected}
+        aria-selected={isSelected || isMultiSelected}
         aria-disabled={isBankLoading}
         data-drag-over={isDragOver ? 'true' : undefined}
+        data-multi-selected={isMultiSelected ? 'true' : undefined}
         data-testid={`device-tone-slot-${index}`}
         onClick={isBankLoading ? undefined : handleClick}
         onKeyDown={(e) => {
           if (isBankLoading) return;
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            handleClick();
+            // Keyboard activation = plain-click semantics (no modifier
+            // key handling on Enter/Space). Bypass the multi dispatcher
+            // and do a direct page-level select so keyboard users get
+            // the same single-select behavior as a plain mouse click.
+            if (tone) onSelectTone(index);
+            else if (!isLoaded && onLoadToneBank) onLoadToneBank(bankIndex);
           }
         }}
         draggable={!!tone}
@@ -334,6 +447,7 @@ export function DeviceMemoryPanel({
         className={cn(
           'ac-device-memory-row',
           tone && 'ac-device-memory-row--draggable',
+          isMultiSelected && 'ac-device-memory-row--multi-selected',
         )}
       >
         <span className="ac-list-slot">{memoryLayout.formatToneSlot(index)}</span>
@@ -361,6 +475,7 @@ export function DeviceMemoryPanel({
   function renderPatchSlot(index: number, bankIndex: number, isBankLoading: boolean): JSX.Element {
     const patch = patches[index];
     const isSelected = selectedType === 'patch' && selectedIndex === index;
+    const isMultiSelected = multiPatches.has(index);
     const isLoaded = loadedPatchBanks.includes(bankIndex);
     const isDragOver = dragOverPatchSlot === index;
     const isEmpty = patch !== undefined && isPatchEmpty(patch);
@@ -369,9 +484,9 @@ export function DeviceMemoryPanel({
       ? '(loading...)'
       : patch?.common.name || '';
 
-    const handleClick = (): void => {
+    const handleClick = (e: React.MouseEvent): void => {
       if (patch) {
-        onSelectPatch(index);
+        handlePatchClick(index, e);
       } else if (!isBankLoading && !isLoaded && onLoadPatchBank) {
         onLoadPatchBank(bankIndex);
       }
@@ -382,16 +497,18 @@ export function DeviceMemoryPanel({
         key={index}
         role="button"
         tabIndex={isBankLoading ? -1 : 0}
-        aria-selected={isSelected}
+        aria-selected={isSelected || isMultiSelected}
         aria-disabled={isBankLoading}
         data-drag-over={isDragOver ? 'true' : undefined}
+        data-multi-selected={isMultiSelected ? 'true' : undefined}
         data-testid={`device-patch-slot-${index}`}
         onClick={isBankLoading ? undefined : handleClick}
         onKeyDown={(e) => {
           if (isBankLoading) return;
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            handleClick();
+            if (patch) onSelectPatch(index);
+            else if (!isLoaded && onLoadPatchBank) onLoadPatchBank(bankIndex);
           }
         }}
         draggable={!!patch}
@@ -404,6 +521,7 @@ export function DeviceMemoryPanel({
           'ac-device-memory-row',
           'ac-device-memory-row--patch',
           patch && 'ac-device-memory-row--draggable',
+          isMultiSelected && 'ac-device-memory-row--multi-selected',
         )}
       >
         <PatchLabel index={index} memoryLayout={memoryLayout} className="ac-list-slot" />
@@ -470,9 +588,7 @@ export function DeviceMemoryPanel({
             aria-controls="device-memory-tones-list"
             data-testid="device-memory-section-toggle-tones"
           >
-            <span className="ac-device-memory-section-eyebrow-chevron" aria-hidden="true">
-              {isTonesExpanded ? '▾' : '▸'}
-            </span>
+            <AcChevron expanded={isTonesExpanded} />
             <span>Tones ({totalTones} slots)</span>
           </button>
           <div className="ac-list" id="device-memory-tones-list" style={{ borderRadius: 0, border: 'none', flex: '1 1 0', minHeight: 0 }}>
@@ -521,9 +637,7 @@ export function DeviceMemoryPanel({
             aria-controls="device-memory-patches-list"
             data-testid="device-memory-section-toggle-patches"
           >
-            <span className="ac-device-memory-section-eyebrow-chevron" aria-hidden="true">
-              {isPatchesExpanded ? '▾' : '▸'}
-            </span>
+            <AcChevron expanded={isPatchesExpanded} />
             <span>Patches ({totalPatches} slots)</span>
           </button>
           <div className="ac-list" id="device-memory-patches-list" style={{ borderRadius: 0, border: 'none', flex: '1 1 0', minHeight: 0 }}>

--- a/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/DeviceMemoryPanel.tsx
@@ -154,10 +154,14 @@ export function DeviceMemoryPanel({
       return;
     }
     if (e.ctrlKey || e.metaKey) {
-      // Capture the prior anchor BEFORE the setMultiTones updater runs.
-      // React batches state updates and runs the updater asynchronously,
-      // so `lastToneAnchorRef.current = index` below would clobber the
-      // ref before the updater reads it — the seed would never fire.
+      // Ctrl/meta-click toggles membership in the multi-set but MUST
+      // NOT move the anchor — otherwise a subsequent shift-click would
+      // range from the most recent ctrl-click slot instead of the
+      // original anchor, contradicting the documented behavior + the
+      // OS-standard file-manager idiom (caught by AUDIT-20260521-01).
+      // The "seed prior anchor on first toggle" logic still applies so
+      // the anchor stays highlighted in the multi-set alongside the
+      // new toggles.
       const priorAnchor = lastToneAnchorRef.current;
       setMultiTones((prev) => {
         const next = new Set(prev);
@@ -167,7 +171,6 @@ export function DeviceMemoryPanel({
         if (next.has(index)) next.delete(index); else next.add(index);
         return next;
       });
-      lastToneAnchorRef.current = index;
       return;
     }
     setMultiTones(new Set());
@@ -186,9 +189,11 @@ export function DeviceMemoryPanel({
       return;
     }
     if (e.ctrlKey || e.metaKey) {
-      // See handleToneClick — capture the prior anchor before the
-      // setMultiPatches updater runs so the seed sees the *prior*
-      // anchor, not the one being assigned below.
+      // See handleToneClick — ctrl/meta does NOT move the anchor; the
+      // anchor stays where the last plain or shift click set it so the
+      // next shift-click ranges from there. The seed logic uses the
+      // CURRENT anchor (not the clicked slot) to keep it highlighted
+      // in the multi-set.
       const priorAnchor = lastPatchAnchorRef.current;
       setMultiPatches((prev) => {
         const next = new Set(prev);
@@ -198,7 +203,6 @@ export function DeviceMemoryPanel({
         if (next.has(index)) next.delete(index); else next.add(index);
         return next;
       });
-      lastPatchAnchorRef.current = index;
       return;
     }
     setMultiPatches(new Set());

--- a/modules/roland-sxx0-editor/src/components/library/ExportPatchDialog.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/ExportPatchDialog.tsx
@@ -52,7 +52,7 @@ export function ExportPatchDialog({
   progress,
   error: operationError,
 }: ExportPatchDialogProps): JSX.Element | null {
-  const { memoryLayout } = useDeviceConfig();
+  const { memoryLayout, deviceName } = useDeviceConfig();
   const slotLabel = memoryLayout.formatPatchSlot(patchIndex);
   // Device-aware default name (S-330: Patch_P11..Patch_P28; S-550:
   // Patch_I11..Patch_IV28). The `Patch_` prefix preserves the
@@ -149,6 +149,7 @@ export function ExportPatchDialog({
         <PatchFormBody
           patch={patch}
           slotLabel={slotLabel}
+          deviceName={deviceName}
           patchName={patchName}
           setPatchName={setPatchName}
           referencedToneCount={referencedToneCount}
@@ -167,6 +168,10 @@ export function ExportPatchDialog({
 interface PatchFormBodyProps {
   patch: S330Patch | null;
   slotLabel: string;
+  /** Active device name from useDeviceConfig — routed in instead of
+   *  hardcoded so the eyebrow shows S-330 / S-550 correctly per
+   *  active surface. AUDIT-20260521-02. */
+  deviceName: string;
   patchName: string;
   setPatchName: (name: string) => void;
   referencedToneCount: number;
@@ -177,6 +182,7 @@ interface PatchFormBodyProps {
 function PatchFormBody({
   patch,
   slotLabel,
+  deviceName,
   patchName,
   setPatchName,
   referencedToneCount,
@@ -192,7 +198,7 @@ function PatchFormBody({
         <span className="ac-detail-eyebrow-sep">·</span>
         <span>LIBRARY</span>
         <span className="ac-detail-eyebrow-sep">·</span>
-        <span>S330</span>
+        <span data-testid="export-patch-device-name">{deviceName.toUpperCase()}</span>
         {targetPath.length > 0 && (
           // Surface the drop-target subfolder so the operator sees where
           // the bundle will land. See ExportToneDialog for context.

--- a/modules/roland-sxx0-editor/src/components/library/ExportPatchDialog.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/ExportPatchDialog.tsx
@@ -1,36 +1,43 @@
 /**
- * Export Patch to Library Dialog
+ * Export Patch to Library Dialog (v3)
  *
- * Dialog for exporting a patch bundle (parameters + all dependent tones) to the sampler library.
- * Shows export progress and allows customizing the patch name.
+ * Right-edge SlideDrawer per the v3 design language. Mirrors
+ * {@link ExportToneDialog}'s chrome — same eyebrow + hairline +
+ * step-log + footer ladder — so the two sibling export flows
+ * stay visually identical. The only differences are the
+ * eyebrow's category token (PATCH instead of TONE), the
+ * detail-summary rows, and the "exported successfully" message
+ * format.
+ *
+ * Like the tone variant, this dialog no longer suffers BUG-001's
+ * silent-failure shape: synchronous throws from the parent hook's
+ * precondition guards are captured into `localError`, coalesce
+ * with `operationError`, and surface as a failed step in the log.
  */
 
 import { useState, useCallback, useEffect, useMemo } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
+import { SlideDrawer } from '@audiocontrol/editor-core';
 import type { S330Patch } from '@audiocontrol/sampler-devices/s330';
-import type { OperationState } from '@/types/import-operation';
-import { isOperationComplete } from '@/types/import-operation';
+import {
+  type OperationState,
+  isOperationComplete,
+} from '@/types/import-operation';
 import { getPatchToneDependencies } from '@/lib/library-service';
 import { useDeviceConfig } from '@/context/DeviceConfigContext';
-import { cn } from '@/lib/utils';
+import { useStepHistory } from '@/hooks/useStepHistory';
 import {
-  OperationProgressBar,
-  OperationErrorBanner,
-  OperationSuccessScreen,
-  OperationButtonContent,
-  DialogCloseButton,
-} from '@/components/ui/ImportStatus';
+  StepLogBody,
+  ExportSummaryRow,
+  renderFooter,
+} from '@/components/library/ExportToneDialog';
 
 export interface ExportPatchDialogProps extends OperationState {
-  /** Whether the dialog is open */
   open: boolean;
-  /** Callback when dialog should close */
   onOpenChange: (open: boolean) => void;
-  /** The patch to export (null if not loaded) */
   patch: S330Patch | null;
-  /** Patch index (for display) */
   patchIndex: number;
-  /** Callback to perform the export - receives patch name and index */
+  /** Library subfolder the export will land in. See ExportToneDialog. */
+  targetPath?: string[];
   onExport: (patchName: string, patchIndex: number) => Promise<void>;
 }
 
@@ -39,180 +46,212 @@ export function ExportPatchDialog({
   onOpenChange,
   patch,
   patchIndex,
+  targetPath,
   onExport,
   isOperating,
   progress,
   error: operationError,
-}: ExportPatchDialogProps): JSX.Element {
+}: ExportPatchDialogProps): JSX.Element | null {
   const { memoryLayout } = useDeviceConfig();
+  const slotLabel = memoryLayout.formatPatchSlot(patchIndex);
   // Device-aware default name (S-330: Patch_P11..Patch_P28; S-550:
-  // Patch_I11..Patch_IV28). Never `Patch_${idx + 1}` — that produces
-  // `Patch_17` for S-550 patch index 16, which has no analogue on the
-  // device. The `Patch_` prefix preserves the "this is a name, not a slot
-  // id" affordance — the default is written to disk as the patch directory
-  // name, and a bare `II11/` directory is uncomfortable as a filename.
-  const defaultPatchName = `Patch_${memoryLayout.formatPatchSlot(patchIndex)}`;
-  const [patchName, setPatchName] = useState(patch?.common.name || defaultPatchName);
+  // Patch_I11..Patch_IV28). The `Patch_` prefix preserves the
+  // "this is a name, not a slot id" affordance — the default is
+  // written to disk as the patch directory name, and a bare
+  // `II11/` directory is uncomfortable as a filename.
+  const defaultPatchName = `Patch_${slotLabel}`;
+
+  const [patchName, setPatchName] = useState(
+    patch?.common.name || defaultPatchName,
+  );
   const [localError, setLocalError] = useState<string | null>(null);
+  const [hasStarted, setHasStarted] = useState(false);
 
-  // Calculate number of referenced tones
-  const referencedToneCount = useMemo(() => {
-    if (!patch) return 0;
-    return getPatchToneDependencies(patch).length;
-  }, [patch]);
+  const referencedToneCount = useMemo(
+    () => (patch ? getPatchToneDependencies(patch).length : 0),
+    [patch],
+  );
 
-  // Reset patch name when dialog opens or patch changes
   useEffect(() => {
     if (open) {
       setPatchName(patch?.common.name || defaultPatchName);
       setLocalError(null);
+      setHasStarted(false);
     }
   }, [open, patch?.common.name, defaultPatchName]);
 
+  const isComplete = isOperationComplete({
+    isOperating,
+    progress,
+    error: operationError,
+  });
+  const effectiveError = localError ?? operationError;
+  const steps = useStepHistory({ progress, isComplete, error: effectiveError });
+
   const handleExport = useCallback(async () => {
-    if (!patchName.trim()) {
+    const trimmed = patchName.trim();
+    if (!trimmed) {
       setLocalError('Patch name is required');
       return;
     }
-
     setLocalError(null);
+    setHasStarted(true);
     try {
-      await onExport(patchName.trim(), patchIndex);
-    } catch {
-      // Error should be handled by parent via operationError prop
+      await onExport(trimmed, patchIndex);
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : 'Export failed');
     }
   }, [patchName, patchIndex, onExport]);
 
   const handleClose = useCallback(() => {
-    if (!isOperating) {
-      setLocalError(null);
-      onOpenChange(false);
-    }
+    if (isOperating) return;
+    setLocalError(null);
+    onOpenChange(false);
   }, [isOperating, onOpenChange]);
 
-  const error = localError || operationError;
-  const isComplete = isOperationComplete({ isOperating, progress, error: operationError });
+  if (!open) return null;
+
+  const footer = renderFooter({
+    hasStarted,
+    isComplete,
+    hasError: !!effectiveError,
+    isOperating,
+    canExport: !!patchName.trim() && !!patch,
+    onCancel: handleClose,
+    onExport: handleExport,
+    onClose: handleClose,
+  });
 
   return (
-    <Dialog.Root open={open} onOpenChange={handleClose}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-        <Dialog.Content data-testid="export-dialog" className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-s330-panel border border-s330-accent rounded-lg shadow-xl w-full max-w-md p-6">
-          <Dialog.Title className="text-lg font-bold text-s330-text mb-4">
-            Export Patch to Library
-          </Dialog.Title>
+    <SlideDrawer
+      open={open}
+      title="Export patch to library"
+      onClose={handleClose}
+      footer={footer}
+    >
+      {hasStarted ? (
+        <StepLogBody
+          steps={steps}
+          isComplete={isComplete}
+          hasError={!!effectiveError}
+          successMessage={
+            <>
+              Patch bundle exported successfully — saved to{' '}
+              <span style={{ fontFamily: 'var(--ac-font-mono)' }}>
+                {patchName.trim()}/
+              </span>{' '}
+              with {referencedToneCount} tone
+              {referencedToneCount !== 1 ? 's' : ''}
+            </>
+          }
+        />
+      ) : (
+        <PatchFormBody
+          patch={patch}
+          slotLabel={slotLabel}
+          patchName={patchName}
+          setPatchName={setPatchName}
+          referencedToneCount={referencedToneCount}
+          targetPath={targetPath ?? []}
+          error={localError}
+        />
+      )}
+    </SlideDrawer>
+  );
+}
 
-          {isComplete ? (
-            <OperationSuccessScreen
-              message="Patch bundle exported successfully!"
-              detail={
-                <p>
-                  Saved to <span className="font-mono text-s330-text">{patchName}/</span> with {referencedToneCount} tone{referencedToneCount !== 1 ? 's' : ''}
-                </p>
-              }
-              onDone={handleClose}
-            />
-          ) : (
-            <div className="space-y-4">
-              <Dialog.Description className="text-sm text-s330-muted">
-                Export patch {memoryLayout.formatPatchSlot(patchIndex)} with all its dependent tones to your sampler library.
-              </Dialog.Description>
+// ---------------------------------------------------------------------------
+// Body — idle form
+// ---------------------------------------------------------------------------
 
-              {/* Patch Name Input */}
-              <div>
-                <label htmlFor="patchName" className="ac-field-label mb-1">
-                  Patch Name
-                </label>
-                <input
-                  id="patchName"
-                  type="text"
-                  value={patchName}
-                  onChange={(e) => setPatchName(e.target.value)}
-                  disabled={isOperating}
-                  maxLength={32}
-                  data-error={error ? 'true' : undefined}
-                  className={cn(
-                    'ac-input',
-                    error && 'ac-input--error',
-                  )}
-                  placeholder="Enter patch name"
-                />
-              </div>
+interface PatchFormBodyProps {
+  patch: S330Patch | null;
+  slotLabel: string;
+  patchName: string;
+  setPatchName: (name: string) => void;
+  referencedToneCount: number;
+  targetPath: string[];
+  error: string | null;
+}
 
-              {/* Patch Info */}
-              {patch && (
-                <div className="bg-s330-bg rounded p-3 text-sm">
-                  <div className="grid grid-cols-2 gap-2">
-                    <div>
-                      <span className="text-s330-muted">Key Mode:</span>
-                      <span className="ml-2 text-s330-text capitalize">{patch.common.keyMode}</span>
-                    </div>
-                    <div>
-                      <span className="text-s330-muted">Level:</span>
-                      <span className="ml-2 text-s330-text">{patch.common.level}</span>
-                    </div>
-                    <div>
-                      <span className="text-s330-muted">Bender Range:</span>
-                      <span className="ml-2 text-s330-text">{patch.common.benderRange}</span>
-                    </div>
-                    <div>
-                      <span className="text-s330-muted">Output:</span>
-                      <span className="ml-2 text-s330-text">
-                        {patch.common.outputAssign === 8 ? 'TONE' : patch.common.outputAssign}
-                      </span>
-                    </div>
-                  </div>
-                  <div className="mt-2 pt-2 border-t border-s330-accent/30">
-                    <span className="text-s330-muted">Dependent Tones:</span>
-                    <span className="ml-2 text-s330-text font-medium">
-                      {referencedToneCount} tone{referencedToneCount !== 1 ? 's' : ''} will be exported
-                    </span>
-                  </div>
-                </div>
-              )}
+function PatchFormBody({
+  patch,
+  slotLabel,
+  patchName,
+  setPatchName,
+  referencedToneCount,
+  targetPath,
+  error,
+}: PatchFormBodyProps): JSX.Element {
+  return (
+    <div className="ac-export-form">
+      <div className="ac-detail-eyebrow-row" data-testid="export-patch-destination">
+        <span className="ac-detail-eyebrow-accent">PATCH</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>{slotLabel}</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>LIBRARY</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>S330</span>
+        {targetPath.length > 0 && (
+          // Surface the drop-target subfolder so the operator sees where
+          // the bundle will land. See ExportToneDialog for context.
+          <>
+            <span className="ac-detail-eyebrow-sep">·</span>
+            <span data-testid="export-patch-target-path">{targetPath.join(' / ')}</span>
+          </>
+        )}
+      </div>
+      <div className="ac-page-title-rule" aria-hidden="true" />
 
-              {/* Progress Bar */}
-              {isOperating && progress && (
-                <OperationProgressBar progress={progress} />
-              )}
+      <div className="ac-export-form-field">
+        <label htmlFor="export-patch-name" className="ac-field-label">
+          Patch name
+        </label>
+        <input
+          id="export-patch-name"
+          type="text"
+          value={patchName}
+          onChange={(e) => setPatchName(e.target.value)}
+          maxLength={32}
+          autoFocus
+          className={`ac-input ${error ? 'ac-input--error' : ''}`}
+          placeholder="Enter patch name"
+          data-testid="export-patch-name-input"
+        />
+        {error && (
+          <p className="ac-export-form-error" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
 
-              {/* Error Display */}
-              {error && <OperationErrorBanner error={error} />}
-
-              {/* Actions */}
-              <div className="flex justify-end gap-2">
-                <button
-                  onClick={handleClose}
-                  disabled={isOperating}
-                  data-testid="export-cancel"
-                  className={cn(
-                    'ac-btn ac-btn-ghost',
-                    isOperating && 'opacity-50 cursor-not-allowed'
-                  )}
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleExport}
-                  disabled={isOperating || !patchName.trim() || !patch}
-                  data-testid="export-confirm"
-                  className={cn(
-                    'ac-btn ac-btn-primary',
-                    (isOperating || !patchName.trim() || !patch) && 'opacity-50 cursor-not-allowed'
-                  )}
-                >
-                  <OperationButtonContent isOperating={isOperating} label="Export" operatingLabel="Exporting..." />
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Close button */}
-          <Dialog.Close asChild>
-            <DialogCloseButton disabled={isOperating} />
-          </Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+      {patch && (
+        <dl className="ac-export-summary">
+          <ExportSummaryRow
+            label="Key mode"
+            value={patch.common.keyMode}
+            valueStyle="capitalize"
+          />
+          <ExportSummaryRow label="Level" value={String(patch.common.level)} />
+          <ExportSummaryRow
+            label="Bender range"
+            value={String(patch.common.benderRange)}
+          />
+          <ExportSummaryRow
+            label="Output"
+            value={
+              patch.common.outputAssign === 8
+                ? 'TONE'
+                : String(patch.common.outputAssign)
+            }
+          />
+          <ExportSummaryRow
+            label="Dependent tones"
+            value={`${referencedToneCount} tone${referencedToneCount !== 1 ? 's' : ''} will be exported`}
+          />
+        </dl>
+      )}
+    </div>
   );
 }

--- a/modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx
@@ -1,34 +1,45 @@
 /**
- * Export Tone to Library Dialog
+ * Export Tone to Library Dialog (v3)
  *
- * Dialog for exporting a tone (parameters + wave data) to the sampler library.
- * Shows export progress and allows customizing the tone name.
+ * Right-edge SlideDrawer per the v3 design language: the library
+ * tree and device memory stay visible while the drawer is open so
+ * the operator keeps source-slot + destination context in view.
+ *
+ * Two body modes drawn into a single SlideDrawer (so the drawer
+ * panel never remounts mid-operation):
+ *   - Idle:  tone-name + tone-detail readout + Export action
+ *   - Run/Done/Fail: shared step-log (`ac-step-*`) growing in
+ *     place as `OperationProgress` ticks
+ *
+ * Replaces the legacy centered Radix.Dialog. The empty `catch {}`
+ * silent-failure shape from BUG-001 disappears here: any thrown
+ * error from `onExport` is captured into `localError`, coalesced
+ * with `operationError`, and feeds the step log's failed-state row.
  */
 
-import { useState, useCallback, useEffect } from 'react';
-import * as Dialog from '@radix-ui/react-dialog';
-import type { S330Tone } from '@audiocontrol/sampler-devices/s330';
-import type { OperationState } from '@/types/import-operation';
-import { isOperationComplete } from '@/types/import-operation';
-import { cn } from '@/lib/utils';
+import { useState, useCallback, useEffect, type ReactNode } from 'react';
 import {
-  OperationProgressBar,
-  OperationErrorBanner,
-  OperationSuccessScreen,
-  OperationButtonContent,
-  DialogCloseButton,
-} from '@/components/ui/ImportStatus';
+  SlideDrawer,
+  StepRow,
+  type ProgressStep,
+} from '@audiocontrol/editor-core';
+import { useDeviceConfig } from '@/context/DeviceConfigContext';
+import type { S330Tone } from '@audiocontrol/sampler-devices/s330';
+import {
+  type OperationState,
+  isOperationComplete,
+} from '@/types/import-operation';
+import { useStepHistory } from '@/hooks/useStepHistory';
 
 export interface ExportToneDialogProps extends OperationState {
-  /** Whether the dialog is open */
   open: boolean;
-  /** Callback when dialog should close */
   onOpenChange: (open: boolean) => void;
-  /** The tone to export (null if not loaded) */
   tone: S330Tone | null;
-  /** Tone index (for display) */
   toneIndex: number;
-  /** Callback to perform the export - receives tone name and index */
+  /** Library subfolder the export will land in (e.g. ['DRUMS']). When
+   *  non-empty, the eyebrow row surfaces it so the operator sees the
+   *  destination before clicking Export. Defaults to []. */
+  targetPath?: string[];
   onExport: (toneName: string, toneIndex: number) => Promise<void>;
 }
 
@@ -37,154 +48,324 @@ export function ExportToneDialog({
   onOpenChange,
   tone,
   toneIndex,
+  targetPath,
   onExport,
   isOperating,
   progress,
   error: operationError,
-}: ExportToneDialogProps): JSX.Element {
-  const [toneName, setToneName] = useState(tone?.name || `Tone_${toneIndex + 1}`);
-  const [localError, setLocalError] = useState<string | null>(null);
+}: ExportToneDialogProps): JSX.Element | null {
+  const { memoryLayout } = useDeviceConfig();
+  const slotLabel = memoryLayout.formatToneSlot(toneIndex);
 
-  // Reset tone name when dialog opens or tone changes
+  const [toneName, setToneName] = useState(tone?.name || `Tone_${slotLabel}`);
+  const [localError, setLocalError] = useState<string | null>(null);
+  const [hasStarted, setHasStarted] = useState(false);
+
+  // Reset on (re)open.
   useEffect(() => {
     if (open) {
-      setToneName(tone?.name || `Tone_${toneIndex + 1}`);
+      setToneName(tone?.name || `Tone_${slotLabel}`);
       setLocalError(null);
+      setHasStarted(false);
     }
-  }, [open, tone?.name, toneIndex]);
+  }, [open, tone?.name, slotLabel]);
+
+  const isComplete = isOperationComplete({
+    isOperating,
+    progress,
+    error: operationError,
+  });
+  const effectiveError = localError ?? operationError;
+  const steps = useStepHistory({ progress, isComplete, error: effectiveError });
 
   const handleExport = useCallback(async () => {
-    if (!toneName.trim()) {
+    const trimmed = toneName.trim();
+    if (!trimmed) {
       setLocalError('Tone name is required');
       return;
     }
-
     setLocalError(null);
+    setHasStarted(true);
     try {
-      await onExport(toneName.trim(), toneIndex);
+      await onExport(trimmed, toneIndex);
     } catch (err) {
-      // Error should be handled by parent via operationError prop
+      // Coalesces with `operationError` via `effectiveError`. Without
+      // this, the synchronous precondition throws in the parent hook
+      // (e.g. `!libraryHandle`) would vanish — that is BUG-001.
+      setLocalError(err instanceof Error ? err.message : 'Export failed');
     }
   }, [toneName, toneIndex, onExport]);
 
   const handleClose = useCallback(() => {
-    if (!isOperating) {
-      setLocalError(null);
-      onOpenChange(false);
-    }
+    if (isOperating) return;
+    setLocalError(null);
+    onOpenChange(false);
   }, [isOperating, onOpenChange]);
 
-  const error = localError || operationError;
-  const isComplete = isOperationComplete({ isOperating, progress, error: operationError });
+  if (!open) return null;
+
+  const footer = renderFooter({
+    hasStarted,
+    isComplete,
+    hasError: !!effectiveError,
+    isOperating,
+    canExport: !!toneName.trim() && !!tone,
+    onCancel: handleClose,
+    onExport: handleExport,
+    onClose: handleClose,
+  });
 
   return (
-    <Dialog.Root open={open} onOpenChange={handleClose}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-50" />
-        <Dialog.Content data-testid="export-dialog" className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-50 bg-s330-panel border border-s330-accent rounded-lg shadow-xl w-full max-w-md p-6">
-          <Dialog.Title className="text-lg font-bold text-s330-text mb-4">
-            Export Tone to Library
-          </Dialog.Title>
+    <SlideDrawer
+      open={open}
+      title="Export tone to library"
+      onClose={handleClose}
+      footer={footer}
+    >
+      {hasStarted ? (
+        <StepLogBody
+          steps={steps}
+          isComplete={isComplete}
+          hasError={!!effectiveError}
+          successMessage={
+            <>
+              Tone exported successfully — saved as{' '}
+              <span style={{ fontFamily: 'var(--ac-font-mono)' }}>
+                {toneName.trim()}.yaml
+              </span>
+            </>
+          }
+        />
+      ) : (
+        <ToneFormBody
+          tone={tone}
+          slotLabel={slotLabel}
+          toneName={toneName}
+          setToneName={setToneName}
+          targetPath={targetPath ?? []}
+          error={localError}
+        />
+      )}
+    </SlideDrawer>
+  );
+}
 
-          {isComplete ? (
-            <OperationSuccessScreen
-              message="Tone exported successfully!"
-              detail={
-                <p>
-                  Saved as <span className="font-mono text-s330-text">{toneName}.yaml</span>
-                </p>
-              }
-              onDone={handleClose}
-            />
-          ) : (
-            <div className="space-y-4">
-              <Dialog.Description className="text-sm text-s330-muted">
-                Export tone T{toneIndex + 1} parameters and wave data to your sampler library.
-              </Dialog.Description>
+// ---------------------------------------------------------------------------
+// Body — idle form
+// ---------------------------------------------------------------------------
 
-              {/* Tone Name Input */}
-              <div>
-                <label htmlFor="toneName" className="ac-field-label mb-1">
-                  Tone Name
-                </label>
-                <input
-                  id="toneName"
-                  type="text"
-                  value={toneName}
-                  onChange={(e) => setToneName(e.target.value)}
-                  disabled={isOperating}
-                  maxLength={32}
-                  className={cn('ac-input', error && 'ac-input--error')}
-                  placeholder="Enter tone name"
-                />
-              </div>
+interface ToneFormBodyProps {
+  tone: S330Tone | null;
+  slotLabel: string;
+  toneName: string;
+  setToneName: (name: string) => void;
+  targetPath: string[];
+  error: string | null;
+}
 
-              {/* Tone Info */}
-              {tone && (
-                <div className="bg-s330-bg rounded p-3 text-sm">
-                  <div className="grid grid-cols-2 gap-2">
-                    <div>
-                      <span className="text-s330-muted">Sample Rate:</span>
-                      <span className="ml-2 text-s330-text">{tone.sampleRate}</span>
-                    </div>
-                    <div>
-                      <span className="text-s330-muted">Loop Mode:</span>
-                      <span className="ml-2 text-s330-text capitalize">{tone.loopMode}</span>
-                    </div>
-                    <div>
-                      <span className="text-s330-muted">Original Key:</span>
-                      <span className="ml-2 text-s330-text">{tone.originalKey}</span>
-                    </div>
-                    <div>
-                      <span className="text-s330-muted">TVF:</span>
-                      <span className="ml-2 text-s330-text">{tone.tvf.enabled ? 'ON' : 'OFF'}</span>
-                    </div>
-                  </div>
-                </div>
-              )}
+function ToneFormBody({
+  tone,
+  slotLabel,
+  toneName,
+  setToneName,
+  targetPath,
+  error,
+}: ToneFormBodyProps): JSX.Element {
+  return (
+    <div className="ac-export-form">
+      <div className="ac-detail-eyebrow-row" data-testid="export-tone-destination">
+        <span className="ac-detail-eyebrow-accent">TONE</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>{slotLabel}</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>LIBRARY</span>
+        <span className="ac-detail-eyebrow-sep">·</span>
+        <span>S330</span>
+        {targetPath.length > 0 && (
+          // Surface the drop-target subfolder so the operator confirms
+          // the export will land where they intended. Drops on a folder
+          // row populate this from `handleExternalDrop`; drops on the
+          // category root leave it empty and we hide the segment.
+          <>
+            <span className="ac-detail-eyebrow-sep">·</span>
+            <span data-testid="export-tone-target-path">{targetPath.join(' / ')}</span>
+          </>
+        )}
+      </div>
+      <div className="ac-page-title-rule" aria-hidden="true" />
 
-              {/* Progress Bar */}
-              {isOperating && progress && (
-                <OperationProgressBar progress={progress} />
-              )}
+      <div className="ac-export-form-field">
+        <label htmlFor="export-tone-name" className="ac-field-label">
+          Tone name
+        </label>
+        <input
+          id="export-tone-name"
+          type="text"
+          value={toneName}
+          onChange={(e) => setToneName(e.target.value)}
+          maxLength={32}
+          autoFocus
+          className={`ac-input ${error ? 'ac-input--error' : ''}`}
+          placeholder="Enter tone name"
+          data-testid="export-tone-name-input"
+        />
+        {error && (
+          <p className="ac-export-form-error" role="alert">
+            {error}
+          </p>
+        )}
+      </div>
 
-              {/* Error Display */}
-              {error && <OperationErrorBanner error={error} />}
+      {tone && (
+        <dl className="ac-export-summary">
+          <ExportSummaryRow label="Sample rate" value={tone.sampleRate} />
+          <ExportSummaryRow
+            label="Loop mode"
+            value={tone.loopMode}
+            valueStyle="capitalize"
+          />
+          <ExportSummaryRow label="Original key" value={String(tone.originalKey)} />
+          <ExportSummaryRow label="TVF" value={tone.tvf.enabled ? 'ON' : 'OFF'} />
+        </dl>
+      )}
+    </div>
+  );
+}
 
-              {/* Actions */}
-              <div className="flex justify-end gap-2">
-                <button
-                  onClick={handleClose}
-                  disabled={isOperating}
-                  data-testid="export-cancel"
-                  className={cn(
-                    'ac-btn ac-btn-ghost',
-                    isOperating && 'opacity-50 cursor-not-allowed'
-                  )}
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={handleExport}
-                  disabled={isOperating || !toneName.trim() || !tone}
-                  data-testid="export-confirm"
-                  className={cn(
-                    'ac-btn ac-btn-primary',
-                    (isOperating || !toneName.trim() || !tone) && 'opacity-50 cursor-not-allowed'
-                  )}
-                >
-                  <OperationButtonContent isOperating={isOperating} label="Export" operatingLabel="Exporting..." />
-                </button>
-              </div>
-            </div>
-          )}
+// ---------------------------------------------------------------------------
+// Body — running / complete / failed step log
+// ---------------------------------------------------------------------------
 
-          {/* Close button */}
-          <Dialog.Close asChild>
-            <DialogCloseButton disabled={isOperating} />
-          </Dialog.Close>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+interface StepLogBodyProps {
+  steps: ProgressStep[];
+  isComplete: boolean;
+  hasError: boolean;
+  successMessage: ReactNode;
+}
+
+export function StepLogBody({
+  steps,
+  isComplete,
+  hasError,
+  successMessage,
+}: StepLogBodyProps): JSX.Element {
+  return (
+    <div className="ac-stepped-progress">
+      {steps.map((step) => (
+        <StepRow key={step.id} step={step} />
+      ))}
+      {isComplete && !hasError && (
+        <div className="ac-step-summary">{successMessage}</div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared bits
+// ---------------------------------------------------------------------------
+
+interface ExportSummaryRowProps {
+  label: string;
+  value: string;
+  valueStyle?: 'capitalize';
+}
+
+export function ExportSummaryRow({
+  label,
+  value,
+  valueStyle,
+}: ExportSummaryRowProps): JSX.Element {
+  return (
+    <div className="ac-export-summary-row">
+      <dt>{label}</dt>
+      <dd className={valueStyle === 'capitalize' ? 'ac-capitalize' : undefined}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+interface FooterParams {
+  hasStarted: boolean;
+  isComplete: boolean;
+  hasError: boolean;
+  isOperating: boolean;
+  canExport: boolean;
+  onCancel: () => void;
+  onExport: () => void;
+  onClose: () => void;
+}
+
+export function renderFooter({
+  hasStarted,
+  isComplete,
+  hasError,
+  isOperating,
+  canExport,
+  onCancel,
+  onExport,
+  onClose,
+}: FooterParams): JSX.Element {
+  if (!hasStarted) {
+    return (
+      <>
+        <button
+          type="button"
+          className="ac-btn ac-btn-sm"
+          onClick={onCancel}
+          data-testid="export-cancel"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="ac-btn ac-btn-sm ac-btn-primary"
+          onClick={onExport}
+          disabled={!canExport}
+          data-testid="export-confirm"
+        >
+          Export
+        </button>
+      </>
+    );
+  }
+  if (isComplete && !hasError) {
+    return (
+      <button
+        type="button"
+        className="ac-btn ac-btn-sm ac-btn-primary"
+        onClick={onClose}
+        data-testid="export-cancel"
+      >
+        Done
+      </button>
+    );
+  }
+  if (hasError) {
+    return (
+      <button
+        type="button"
+        className="ac-btn ac-btn-sm"
+        onClick={onClose}
+        data-testid="export-cancel"
+      >
+        Close
+      </button>
+    );
+  }
+  // Running: cancel is unavailable today (the export hook has no abort
+  // signal). Show the button as disabled so the affordance is visible
+  // and the test selector remains stable.
+  return (
+    <button
+      type="button"
+      className="ac-btn ac-btn-sm"
+      disabled
+      data-testid="export-cancel"
+      title={isOperating ? 'Export in progress' : ''}
+    >
+      Cancel
+    </button>
   );
 }

--- a/modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/ExportToneDialog.tsx
@@ -54,7 +54,7 @@ export function ExportToneDialog({
   progress,
   error: operationError,
 }: ExportToneDialogProps): JSX.Element | null {
-  const { memoryLayout } = useDeviceConfig();
+  const { memoryLayout, deviceName } = useDeviceConfig();
   const slotLabel = memoryLayout.formatToneSlot(toneIndex);
 
   const [toneName, setToneName] = useState(tone?.name || `Tone_${slotLabel}`);
@@ -140,6 +140,7 @@ export function ExportToneDialog({
         <ToneFormBody
           tone={tone}
           slotLabel={slotLabel}
+          deviceName={deviceName}
           toneName={toneName}
           setToneName={setToneName}
           targetPath={targetPath ?? []}
@@ -157,6 +158,10 @@ export function ExportToneDialog({
 interface ToneFormBodyProps {
   tone: S330Tone | null;
   slotLabel: string;
+  /** Active device name from useDeviceConfig (e.g. "S-330", "S-550") —
+   *  routed in instead of hardcoded so the eyebrow correctly reflects
+   *  whichever Roland surface the editor is mounted under. AUDIT-20260521-02. */
+  deviceName: string;
   toneName: string;
   setToneName: (name: string) => void;
   targetPath: string[];
@@ -166,6 +171,7 @@ interface ToneFormBodyProps {
 function ToneFormBody({
   tone,
   slotLabel,
+  deviceName,
   toneName,
   setToneName,
   targetPath,
@@ -180,7 +186,7 @@ function ToneFormBody({
         <span className="ac-detail-eyebrow-sep">·</span>
         <span>LIBRARY</span>
         <span className="ac-detail-eyebrow-sep">·</span>
-        <span>S330</span>
+        <span data-testid="export-tone-device-name">{deviceName.toUpperCase()}</span>
         {targetPath.length > 0 && (
           // Surface the drop-target subfolder so the operator confirms
           // the export will land where they intended. Drops on a folder

--- a/modules/roland-sxx0-editor/src/components/library/ItemPreviewPanel.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/ItemPreviewPanel.tsx
@@ -47,6 +47,14 @@ interface ItemPreviewPanelProps {
   onLoadSet?: () => void;
   onOpenInLoopEditor?: (name: string, nodeType: string, path?: string[]) => void;
   onOpenInSampleEditor?: (name: string, nodeType: string, path?: string[]) => void;
+  /** Open the v3 export drawer for a device-resident tone. */
+  onExportDeviceTone?: (toneIndex: number) => void;
+  /** Open the v3 export drawer for a device-resident patch. */
+  onExportDevicePatch?: (patchIndex: number) => void;
+  /** Pre-select the slot in the editor store and route to /tones. */
+  onEditDeviceTone?: (toneIndex: number) => void;
+  /** Pre-select the slot in the editor store and route to /patches. */
+  onEditDevicePatch?: (patchIndex: number) => void;
 }
 
 // ---------------------------------------------------------------
@@ -173,6 +181,10 @@ export function ItemPreviewPanel({
   onImportPatch,
   onImportIndividualTone,
   onImportIndividualPatch,
+  onExportDeviceTone,
+  onExportDevicePatch,
+  onEditDeviceTone,
+  onEditDevicePatch,
   onLoadSet,
   onOpenInLoopEditor,
   onOpenInSampleEditor,
@@ -268,13 +280,35 @@ export function ItemPreviewPanel({
   // ---- Device tone -------------------------------------------------
   if (selection.source === 'device' && selection.type === 'tone' && selection.index !== undefined) {
     const tone = deviceTones[selection.index];
+    const toneIndex = selection.index;
     return (
       <PreviewPane title="Device Tone">
         {tone ? (
           <TonePreviewBody
             tone={tone}
             kind="Device Tone"
-            slot={memoryLayout.formatToneSlot(selection.index)}
+            slot={memoryLayout.formatToneSlot(toneIndex)}
+            actions={
+              (onExportDeviceTone || onEditDeviceTone) ? (
+                <div className="ac-pane-actions">
+                  {onExportDeviceTone && (
+                    <PaneAction
+                      label="Export to Library"
+                      variant="primary"
+                      onClick={() => onExportDeviceTone(toneIndex)}
+                      testId="export-device-tone-button"
+                    />
+                  )}
+                  {onEditDeviceTone && (
+                    <PaneAction
+                      label="Edit in Tone Editor"
+                      onClick={() => onEditDeviceTone(toneIndex)}
+                      testId="edit-device-tone-button"
+                    />
+                  )}
+                </div>
+              ) : undefined
+            }
           />
         ) : (
           <EmptySlotMessage message="Empty slot" />
@@ -286,13 +320,35 @@ export function ItemPreviewPanel({
   // ---- Device patch ------------------------------------------------
   if (selection.source === 'device' && selection.type === 'patch' && selection.index !== undefined) {
     const patch = devicePatches[selection.index];
+    const patchIndex = selection.index;
     return (
       <PreviewPane title="Device Patch">
         {patch ? (
           <PatchPreviewBody
             patch={patch}
             kind="Device Patch"
-            slot={memoryLayout.formatPatchSlot(selection.index)}
+            slot={memoryLayout.formatPatchSlot(patchIndex)}
+            actions={
+              (onExportDevicePatch || onEditDevicePatch) ? (
+                <div className="ac-pane-actions">
+                  {onExportDevicePatch && (
+                    <PaneAction
+                      label="Export to Library"
+                      variant="primary"
+                      onClick={() => onExportDevicePatch(patchIndex)}
+                      testId="export-device-patch-button"
+                    />
+                  )}
+                  {onEditDevicePatch && (
+                    <PaneAction
+                      label="Edit in Patch Editor"
+                      onClick={() => onEditDevicePatch(patchIndex)}
+                      testId="edit-device-patch-button"
+                    />
+                  )}
+                </div>
+              ) : undefined
+            }
           />
         ) : (
           <EmptySlotMessage message="Empty slot" />

--- a/modules/roland-sxx0-editor/src/components/library/LibraryTreeIcons.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/LibraryTreeIcons.tsx
@@ -28,15 +28,15 @@ export function FolderIcon({ isOpen: _isOpen }: { isOpen: boolean }): JSX.Elemen
   );
 }
 
-/** Chevron — Unicode glyph swap matching the bank-header chevron in
- *  ToneList / PatchList and the section-eyebrow chevron in
- *  DeviceMemoryPanel. Single shared vocabulary across all three. */
+/** Legacy alias for the AcChevron primitive. The S330/S550 tree rows
+ *  still import ChevronIcon from this module; this thin wrapper keeps
+ *  those call-sites working without re-routing them all through
+ *  editor-core. Owns no styling — the AcChevron component is the sole
+ *  source of chevron sizing/color/glyph. */
+import { AcChevron } from '@audiocontrol/editor-core';
+
 export function ChevronIcon({ isExpanded }: { isExpanded: boolean }): JSX.Element {
-  return (
-    <span className="ac-tree-chevron" aria-hidden="true">
-      {isExpanded ? '▾' : '▸'}
-    </span>
-  );
+  return <AcChevron expanded={isExpanded} />;
 }
 
 /** Wave icon for tones. */

--- a/modules/roland-sxx0-editor/src/components/library/SetItem.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/SetItem.tsx
@@ -122,7 +122,7 @@ export function SetItem({
         tabIndex={isEditing ? -1 : 0}
         onKeyDown={(e) => !isEditing && e.key === 'Enter' && onSelect()}
       >
-        <span className="expand-toggle ac-tree-chevron-btn">
+        <span className="expand-toggle ac-tree-disclosure-btn">
           <ChevronIcon isExpanded={isExpanded} />
         </span>
         <FolderIcon isOpen={isExpanded} />

--- a/modules/roland-sxx0-editor/src/components/library/SetsSection.tsx
+++ b/modules/roland-sxx0-editor/src/components/library/SetsSection.tsx
@@ -10,6 +10,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import type { SetInfo, SetYaml, StorageDirectoryHandle } from '@audiocontrol/sampler-library/browser';
 import type { ItemSelection } from '@audiocontrol/editor-core';
+import { AcChevron } from '@audiocontrol/editor-core';
 import { loadSetManifest } from '@/lib/library-sets';
 import { SetItem } from '@/components/library/SetItem';
 
@@ -83,36 +84,60 @@ export function SetsSection({
     }
   }, [expandedSets, libraryHandle, manifests, loadingManifests]);
 
+  // Mirrors the editor-core TreeSection's collapse pattern so Sets
+  // reads as a peer of Tones/Patches/Samples/Programs in the v3
+  // library tree (chevron + click-to-toggle, body hidden when
+  // collapsed). Default expanded.
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const expanded = !isCollapsed;
+
   return (
-    <div className="ac-tree-section">
-      <div className="ac-tree-section-header">
-        <span className="ac-tree-section-title">Sets</span>
+    <div
+      className={`ac-tree-section${expanded ? '' : ' ac-tree-section--collapsed'}`}
+      data-category="sets"
+      data-testid="library-sets-section"
+      data-expanded={expanded}
+    >
+      <div className="ac-tree-section-header" data-testid="library-sets-section-header">
+        <button
+          type="button"
+          className="ac-tree-section-toggle"
+          onClick={() => setIsCollapsed((prev) => !prev)}
+          aria-expanded={expanded}
+          aria-controls="library-sets-section-content"
+          data-testid="library-sets-section-toggle"
+        >
+          <AcChevron expanded={expanded} />
+          <span className="ac-tree-section-title">Sets</span>
+        </button>
       </div>
-      {sets.length === 0 ? (
-        <div className="ac-tree-section-empty">No sets in library</div>
-      ) : (
-        <div>
-          {sets.map((setInfo) => (
-            <SetItem
-              key={setInfo.name}
-              setInfo={setInfo}
-              manifest={manifests.get(setInfo.name) ?? null}
-              isSelected={selection?.categoryId === 'sets' && selection?.node.name === setInfo.name}
-              isExpanded={expandedSets.has(setInfo.name)}
-              selectedItemName={undefined}
-              selectedItemType={undefined}
-              onToggle={() => toggleSet(setInfo.name)}
-              onSelect={() => onSelectSet(setInfo.name)}
-              onSelectTone={(toneFile) => onSelectTone(toneFile, setInfo.name)}
-              onSelectPatch={(patchFile) => onSelectPatch(patchFile, setInfo.name)}
-              onToneDragStart={() => {}}
-              onPatchDragStart={() => {}}
-              isLoadingManifest={loadingManifests.has(setInfo.name)}
-              onDelete={onDeleteSet ? () => onDeleteSet(setInfo.name) : undefined}
-              onRename={onRenameSet ? (newName) => onRenameSet(setInfo.name, newName) : undefined}
-            />
-          ))}
-        </div>
+      {expanded && (
+        sets.length === 0 ? (
+          <div className="ac-tree-section-empty">No sets in library</div>
+        ) : (
+          <div id="library-sets-section-content" data-testid="library-sets-section-content">
+            {sets.map((setInfo) => (
+              <SetItem
+                key={setInfo.name}
+                setInfo={setInfo}
+                manifest={manifests.get(setInfo.name) ?? null}
+                isSelected={selection?.categoryId === 'sets' && selection?.node.name === setInfo.name}
+                isExpanded={expandedSets.has(setInfo.name)}
+                selectedItemName={undefined}
+                selectedItemType={undefined}
+                onToggle={() => toggleSet(setInfo.name)}
+                onSelect={() => onSelectSet(setInfo.name)}
+                onSelectTone={(toneFile) => onSelectTone(toneFile, setInfo.name)}
+                onSelectPatch={(patchFile) => onSelectPatch(patchFile, setInfo.name)}
+                onToneDragStart={() => {}}
+                onPatchDragStart={() => {}}
+                isLoadingManifest={loadingManifests.has(setInfo.name)}
+                onDelete={onDeleteSet ? () => onDeleteSet(setInfo.name) : undefined}
+                onRename={onRenameSet ? (newName) => onRenameSet(setInfo.name, newName) : undefined}
+              />
+            ))}
+          </div>
+        )
       )}
     </div>
   );

--- a/modules/roland-sxx0-editor/src/components/patches/PatchList.tsx
+++ b/modules/roland-sxx0-editor/src/components/patches/PatchList.tsx
@@ -24,6 +24,7 @@ import { cn } from '@/lib/utils';
 import { useDeviceConfig } from '@/context/DeviceConfigContext';
 import { PatchLabel } from '@/components/common/PatchLabel';
 import { isPatchEmpty } from '@/lib/slot-allocation';
+import { AcChevron } from '@audiocontrol/editor-core';
 
 interface PatchListProps {
   /** Sparse array of patches - undefined = not loaded */
@@ -114,9 +115,7 @@ export function PatchList({
                   aria-label={`Toggle bank ${bankIndex + 1}`}
                   data-testid={`patch-bank-toggle-${bankIndex}`}
                 >
-                  <span className="ac-list-bank-chevron" aria-hidden="true">
-                    {isCollapsed ? '▸' : '▾'}
-                  </span>
+                  <AcChevron expanded={!isCollapsed} />
                   <span>Bank {bankIndex + 1}</span>
                 </button>
                 <span className="ac-list-bank-meta">

--- a/modules/roland-sxx0-editor/src/components/tones/ToneList.tsx
+++ b/modules/roland-sxx0-editor/src/components/tones/ToneList.tsx
@@ -22,6 +22,7 @@ import type { SamplerTone } from '@/core/midi/SamplerClient';
 import { cn } from '@/lib/utils';
 import { useDeviceConfig } from '@/context/DeviceConfigContext';
 import { isToneEmpty } from '@/lib/slot-allocation';
+import { AcChevron } from '@audiocontrol/editor-core';
 
 interface ToneListProps {
   /** Sparse array of tones - undefined = not loaded */
@@ -104,9 +105,7 @@ export function ToneList({
                   aria-label={`Toggle bank ${bankIndex + 1}`}
                   data-testid={`tone-bank-toggle-${bankIndex}`}
                 >
-                  <span className="ac-list-bank-chevron" aria-hidden="true">
-                    {isCollapsed ? '▸' : '▾'}
-                  </span>
+                  <AcChevron expanded={!isCollapsed} />
                   <span>Bank {bankIndex + 1}</span>
                 </button>
                 <span className="ac-list-bank-meta">

--- a/modules/roland-sxx0-editor/src/components/tones/panels/ToneFilterPanel.tsx
+++ b/modules/roland-sxx0-editor/src/components/tones/panels/ToneFilterPanel.tsx
@@ -95,9 +95,9 @@ export function ToneFilterPanel({ tone, onUpdate, onCommit }: ToneFilterPanelPro
           full-width Enable Filter checkbox above the sliders, and
           matches the visual rhythm of the toggles in the Wave panel
           (BANK / LOOP MODE / OUTPUT). */}
-      <div className="tones__compact-grid">
+      <div className="ac-compact-grid">
         <Tooltip content={TONE_TOOLTIPS.tvfEnabled}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Filter</span>
             <AcToggle
               value={tvf.enabled ? 'on' : 'off'}
@@ -109,7 +109,7 @@ export function ToneFilterPanel({ tone, onUpdate, onCommit }: ToneFilterPanelPro
           </div>
         </Tooltip>
         <Tooltip content={TONE_TOOLTIPS.tvfEgPolarity}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">EG Polarity</span>
             <AcToggle
               value={tvf.egPolarity}

--- a/modules/roland-sxx0-editor/src/components/tones/panels/TonePitchLfoPanel.tsx
+++ b/modules/roland-sxx0-editor/src/components/tones/panels/TonePitchLfoPanel.tsx
@@ -125,9 +125,9 @@ export function TonePitchLfoPanel({ tone, onUpdate, onCommit }: Props): JSX.Elem
         />
       </div>
 
-      <div className="tones__compact-grid">
+      <div className="ac-compact-grid">
         <Tooltip content={TONE_TOOLTIPS.pitchFollow}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Pitch Follow</span>
             <AcToggle
               value={tone.pitchFollow ? 'on' : 'off'}
@@ -139,7 +139,7 @@ export function TonePitchLfoPanel({ tone, onUpdate, onCommit }: Props): JSX.Elem
           </div>
         </Tooltip>
         <Tooltip content={TONE_TOOLTIPS.benderEnabled}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Pitch Bender</span>
             <AcToggle
               value={tone.benderEnabled ? 'on' : 'off'}
@@ -151,7 +151,7 @@ export function TonePitchLfoPanel({ tone, onUpdate, onCommit }: Props): JSX.Elem
           </div>
         </Tooltip>
         <Tooltip content={TONE_TOOLTIPS.aftertouchEnabled}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Aftertouch</span>
             <AcToggle
               value={tone.aftertouchEnabled ? 'on' : 'off'}
@@ -179,9 +179,9 @@ export function TonePitchLfoPanel({ tone, onUpdate, onCommit }: Props): JSX.Elem
         <ParamSliderRow label="Offset" value={lfo.offset} onChange={handleOffsetChange} tooltip={TONE_TOOLTIPS.lfoOffset} />
       </div>
 
-      <div className="tones__compact-grid">
+      <div className="ac-compact-grid">
         <Tooltip content={TONE_TOOLTIPS.lfoSync}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Key Sync</span>
             <AcToggle
               value={lfo.sync ? 'on' : 'off'}
@@ -193,7 +193,7 @@ export function TonePitchLfoPanel({ tone, onUpdate, onCommit }: Props): JSX.Elem
           </div>
         </Tooltip>
         <Tooltip content={TONE_TOOLTIPS.lfoMode}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Mode</span>
             <AcToggle
               value={lfo.mode}
@@ -205,7 +205,7 @@ export function TonePitchLfoPanel({ tone, onUpdate, onCommit }: Props): JSX.Elem
           </div>
         </Tooltip>
         <Tooltip content={TONE_TOOLTIPS.lfoPeakHold}>
-          <div className="tones__compact-field">
+          <div className="ac-compact-field">
             <span className="ac-field-label">Peak Hold</span>
             <AcToggle
               value={lfo.polarity ? 'on' : 'off'}

--- a/modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts
+++ b/modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts
@@ -26,11 +26,36 @@ import {
 interface ExportToneDialogState {
   tone: SamplerTone;
   toneIndex: number;
+  /** Library subfolder path the export should land in (e.g. ['DRUMS']).
+   *  Defaults to [] (the patches/tones root). Populated when the user
+   *  drops a device item on a specific folder row rather than on the
+   *  category root — without this the export silently lands at the
+   *  top level no matter where the operator dropped. */
+  targetPath?: string[];
 }
 
 interface ExportPatchDialogState {
   patch: SamplerPatch;
   patchIndex: number;
+  /** Subfolder for the exported patch bundle — see tone dialog above. */
+  targetPath?: string[];
+}
+
+/** Item descriptor for batch export — one row per device slot the operator
+ *  multi-selected before dropping. The `name` is taken from the device at
+ *  capture time and threads through to the library filename slug. */
+export interface BatchExportItem {
+  index: number;
+  name: string;
+  slotLabel: string;
+}
+
+interface BatchExportDialogState {
+  kind: 'tone' | 'patch';
+  items: BatchExportItem[];
+  /** Library subfolder the batch should land in — same shape as the
+   *  single-item dialog's targetPath. */
+  targetPath: string[];
 }
 
 interface UseLibraryExportOptions {
@@ -40,6 +65,17 @@ interface UseLibraryExportOptions {
   patches: (SamplerPatch | undefined)[];
   setIndividualTones: (tones: LibraryToneInfo[]) => void;
   setIndividualPatches: (patches: LibraryPatchInfo[]) => void;
+  /**
+   * Full library re-scan that the LibraryPage exposes (sets +
+   * individual tones + individual patches + samples). Called after
+   * every successful export so the tree picks up the newly written
+   * objects without the operator having to hit the refresh icon —
+   * the partial `setIndividualPatches(updatedPatches)` we used to do
+   * here updated only one slice and missed any sibling state the
+   * tree pane derives from a full refresh (set membership,
+   * cross-category presence checks, etc.).
+   */
+  handleRefreshLibrary: () => Promise<void>;
   /**
    * When true and `libraryHandle` is null, `handleExportTone` falls back to
    * downloading the tone YAML + WAV via `exportToneAsDownload`. When false
@@ -65,14 +101,28 @@ interface UseLibraryExportResult {
   exportPatchProgress: OperationProgress | undefined;
   exportPatchError: string | null;
 
+  // Batch export drawer (tones OR patches). Mutually exclusive with the
+  // single-item dialogs above — a drop with `data.indices.length > 1`
+  // opens this drawer instead of the single dialog.
+  batchExportDialog: BatchExportDialogState | null;
+  batchExportProgress: OperationProgress | undefined;
+  batchExportError: string | null;
+
   // Shared
   isExporting: boolean;
 
   // Handlers
-  handleDropDeviceTone: (data: DeviceDragData) => void;
-  handleDropDevicePatch: (data: DeviceDragData) => void;
+  handleDropDeviceTone: (data: DeviceDragData, targetPath?: string[]) => void;
+  handleDropDevicePatch: (data: DeviceDragData, targetPath?: string[]) => void;
   handleExportTone: (toneName: string, toneIndex: number) => Promise<void>;
   handleExportPatch: (patchName: string, patchIndex: number) => Promise<void>;
+  /** Runs the batch identified by the current `batchExportDialog`. The
+   *  dispatch happens serially (next item starts after the prior write
+   *  resolves) so the SteppedProgressDrawer's "Exporting X of N" step
+   *  log advances one row at a time and the operator sees the device
+   *  cycle through items. The library tree is refreshed once at the
+   *  end (not per-item — that would re-scan O(N²) tree state). */
+  handleBatchExport: () => Promise<void>;
 
   // Imperative dialog openers (for non-DnD entry points: list-row buttons,
   // editor toolbar buttons, etc.). Open the same dialog the drag-and-drop
@@ -83,6 +133,7 @@ interface UseLibraryExportResult {
   // Dialog closers (for onOpenChange)
   closeExportToneDialog: () => void;
   closeExportPatchDialog: () => void;
+  closeBatchExportDialog: () => void;
 }
 
 export function useLibraryExport({
@@ -92,6 +143,7 @@ export function useLibraryExport({
   patches,
   setIndividualTones,
   setIndividualPatches,
+  handleRefreshLibrary,
   allowDownloadFallback = false,
 }: UseLibraryExportOptions): UseLibraryExportResult {
   // Device-aware slot label formatter — used in user-facing progress / error text.
@@ -108,6 +160,14 @@ export function useLibraryExport({
   const [exportPatchDialog, setExportPatchDialog] = useState<ExportPatchDialogState | null>(null);
   const [exportPatchProgress, setExportPatchProgress] = useState<OperationProgress | undefined>(undefined);
   const [exportPatchError, setExportPatchError] = useState<string | null>(null);
+
+  // Batch export drawer state — opened when a drop carries a multi-
+  // index payload (DeviceDragData.indices.length > 1). The drawer
+  // owns its own progress stream so cross-item progress doesn't
+  // collide with the single-item dialog's stream.
+  const [batchExportDialog, setBatchExportDialog] = useState<BatchExportDialogState | null>(null);
+  const [batchExportProgress, setBatchExportProgress] = useState<OperationProgress | undefined>(undefined);
+  const [batchExportError, setBatchExportError] = useState<string | null>(null);
 
   // Shared
   const [isExporting, setIsExporting] = useState(false);
@@ -127,6 +187,14 @@ export function useLibraryExport({
       setExportPatchDialog(null);
       setExportPatchProgress(undefined);
       setExportPatchError(null);
+    }
+  }, [isExporting]);
+
+  const closeBatchExportDialog = useCallback(() => {
+    if (!isExporting) {
+      setBatchExportDialog(null);
+      setBatchExportProgress(undefined);
+      setBatchExportError(null);
     }
   }, [isExporting]);
 
@@ -163,39 +231,80 @@ export function useLibraryExport({
     setExportPatchDialog({ patch, patchIndex });
   }, [patches, libraryHandle]);
 
-  // Handle drop from device memory to library (export tone) - opens dialog
-  const handleDropDeviceTone = useCallback((data: DeviceDragData) => {
+  // Handle drop from device memory to library (export tone). When the
+  // payload's `indices` array has >1 entries, opens the batch drawer;
+  // otherwise opens the single-item dialog. Single is the common case;
+  // batch fires only after the operator multi-selected in the device
+  // memory panel before dragging.
+  const handleDropDeviceTone = useCallback((data: DeviceDragData, targetPath: string[] = []) => {
     if (data.type !== 'tone') {
       return;
     }
-
+    // Batch path: multi-select drag.
+    if (data.indices && data.indices.length > 1) {
+      const items: BatchExportItem[] = [];
+      for (const i of data.indices) {
+        const tone = tones[i];
+        if (!tone) {
+          // Loud failure — the operator just dragged this set; if one
+          // slot isn't loaded, the batch is incoherent and the silent
+          // "skip the missing item" pattern would land an incomplete
+          // export at the destination without telling them.
+          throw new Error(
+            `Tone at ${memoryLayout.formatToneSlot(i)} is not loaded. Reload the bank and try again.`,
+          );
+        }
+        items.push({ index: i, name: tone.name || `Tone_${memoryLayout.formatToneSlot(i)}`, slotLabel: memoryLayout.formatToneSlot(i) });
+      }
+      setBatchExportDialog({ kind: 'tone', items, targetPath });
+      setBatchExportProgress(undefined);
+      setBatchExportError(null);
+      return;
+    }
+    // Single path (existing).
     const tone = tones[data.index];
     if (!tone) {
       throw new Error('Tone not loaded from device. Try refreshing device data first.');
     }
-
-    // Open the export dialog
-    setExportToneDialog({ tone, toneIndex: data.index });
+    setExportToneDialog({ tone, toneIndex: data.index, targetPath });
     setExportProgress(undefined);
     setExportError(null);
-  }, [tones]);
+  }, [tones, memoryLayout]);
 
-  // Handle drop from device memory to library (export patch) - opens dialog
-  const handleDropDevicePatch = useCallback((data: DeviceDragData) => {
+  // Handle drop from device memory to library (export patch) — same
+  // batch detection as the tone sibling above.
+  const handleDropDevicePatch = useCallback((data: DeviceDragData, targetPath: string[] = []) => {
     if (data.type !== 'patch') {
       return;
     }
-
+    if (data.indices && data.indices.length > 1) {
+      const items: BatchExportItem[] = [];
+      for (const i of data.indices) {
+        const patch = patches[i];
+        if (!patch) {
+          throw new Error(
+            `Patch at ${memoryLayout.formatPatchSlot(i)} is not loaded. Reload the bank and try again.`,
+          );
+        }
+        items.push({
+          index: i,
+          name: patch.common.name || `Patch_${memoryLayout.formatPatchSlot(i)}`,
+          slotLabel: memoryLayout.formatPatchSlot(i),
+        });
+      }
+      setBatchExportDialog({ kind: 'patch', items, targetPath });
+      setBatchExportProgress(undefined);
+      setBatchExportError(null);
+      return;
+    }
     const patch = patches[data.index];
     if (!patch) {
       throw new Error('Patch not loaded from device. Try refreshing device data first.');
     }
-
-    // Open the export dialog
-    setExportPatchDialog({ patch, patchIndex: data.index });
+    setExportPatchDialog({ patch, patchIndex: data.index, targetPath });
     setExportPatchProgress(undefined);
     setExportPatchError(null);
-  }, [patches]);
+  }, [patches, memoryLayout]);
 
   // Handle export tone from dialog
   const handleExportTone = useCallback(async (toneName: string, toneIndex: number) => {
@@ -257,7 +366,12 @@ export function useLibraryExport({
           toneName,
           () => {
             // Writing is fast — just keep the progress at step 2
-          }
+          },
+          // targetPath threads through from the drop site so a drop
+          // on a folder row writes into that folder instead of the
+          // tones root (bug pre-2026-05-21: targetPath was discarded
+          // and every drop landed at the top level).
+          exportToneDialog.targetPath ?? [],
         );
       } else {
         // allowDownloadFallback path: download YAML + WAV instead of writing
@@ -276,8 +390,13 @@ export function useLibraryExport({
         bytesTotalAllSteps: waveBytes,
       });
 
-      // Refresh individual tones list (only meaningful when written to library)
+      // Refresh the library tree end-to-end so the newly exported
+      // tone surfaces without the operator hitting the refresh icon.
+      // The partial `listIndividualTones` call below is preserved
+      // for the legacy callers that consume `setIndividualTones`
+      // directly; the canonical refresh is the full re-scan.
       if (libraryHandle) {
+        await handleRefreshLibrary();
         const updatedTones = await listIndividualTones(libraryHandle);
         setIndividualTones(updatedTones);
       }
@@ -289,7 +408,7 @@ export function useLibraryExport({
     } finally {
       setIsExporting(false);
     }
-  }, [libraryHandle, clientRef, exportToneDialog, setIndividualTones, allowDownloadFallback]);
+  }, [libraryHandle, clientRef, exportToneDialog, setIndividualTones, handleRefreshLibrary, allowDownloadFallback]);
 
   // Handle export patch from dialog
   const handleExportPatch = useCallback(async (patchName: string, _patchIndex: number) => {
@@ -307,14 +426,60 @@ export function useLibraryExport({
       // Get all tone slots referenced by this patch
       const referencedSlots = getPatchToneDependencies(patch);
 
-      // Separate original tones (own wave data) from sub-tones (share source tone's wave data)
+      // Auto-fetch any referenced tones that aren't already in the
+      // device-data store. The prior behavior threw "Tone not loaded
+      // from device — refresh first" which forced the operator to go
+      // load every bank that the patch happens to touch. The patch
+      // export already needs MIDI for the wave data; the parameter
+      // dump is a fast SysEx round-trip, so we fetch what's missing
+      // inline. Each fetch becomes a "Resolving tone TXX" row in the
+      // v3 step log so the operator sees the work happening rather
+      // than wondering why the export paused.
+      const fetchedTones = new Map<number, SamplerTone>();
+      let stepCounter = 0;
+
+      const resolveTone = async (slot: number): Promise<SamplerTone> => {
+        const cached = fetchedTones.get(slot);
+        if (cached) return cached;
+        const existing = tones[slot];
+        if (existing) {
+          fetchedTones.set(slot, existing);
+          return existing;
+        }
+        stepCounter += 1;
+        const myStep = stepCounter;
+        setExportPatchProgress({
+          currentStep: myStep,
+          // Total is unknown until classification finishes — the
+          // step-log view ignores `totalSteps` and the v3 dialog
+          // no longer renders the legacy OperationProgressBar, so
+          // equating the two keeps each step's bar at 100% (matches
+          // the discrete-step model of the new chrome).
+          totalSteps: myStep,
+          stepLabel: `Resolving tone ${memoryLayout.formatToneSlot(slot)}`,
+          bytesSent: 0, bytesTotal: 0,
+          bytesSentAllSteps: 0, bytesTotalAllSteps: 0,
+        });
+        const fetched = await client.requestToneData(slot);
+        if (!fetched) {
+          // `requestToneData` resolves null on transport failure / empty
+          // slot. Surface as a real error so the v3 step log's failed
+          // row tells the operator which tone the device wouldn't return.
+          throw new Error(
+            `Device returned no data for tone ${memoryLayout.formatToneSlot(slot)}. ` +
+              `The slot may be empty or the MIDI transport may have failed.`,
+          );
+        }
+        fetchedTones.set(slot, fetched);
+        return fetched;
+      };
+
+      // Phase 1: classify every referenced slot, auto-fetching the
+      // parameter data for any that aren't already in `tones`.
       const originalSlotSet = new Set<number>();
       const subToneSlots: number[] = [];
       for (const slot of referencedSlots) {
-        const tone = tones[slot];
-        if (!tone) {
-          throw new Error(`Tone at slot ${slot} not loaded from device. Try refreshing device data first.`);
-        }
+        const tone = await resolveTone(slot);
         if (toneHasWaveData(tone)) {
           originalSlotSet.add(slot);
         } else {
@@ -322,43 +487,32 @@ export function useLibraryExport({
         }
       }
 
-      // Ensure every sub-tone's source (original) tone is included,
-      // even if the patch doesn't directly reference it
+      // Phase 2: each sub-tone references a source tone whose wave
+      // is the actual sample. Resolve those too if the patch didn't
+      // reference them directly.
       for (const slot of subToneSlots) {
-        const tone = tones[slot]!;
+        const tone = fetchedTones.get(slot)!;
         const sourceSlot = tone.sourceTone;
         if (!originalSlotSet.has(sourceSlot)) {
-          const sourceTone = tones[sourceSlot];
-          if (!sourceTone) {
-            throw new Error(`Source tone ${memoryLayout.formatToneSlot(sourceSlot)} for sub-tone ${memoryLayout.formatToneSlot(slot)} not loaded from device. Try refreshing device data first.`);
-          }
+          await resolveTone(sourceSlot);
           originalSlotSet.add(sourceSlot);
         }
       }
 
       const originalSlots = Array.from(originalSlotSet).sort((a, b) => a - b);
 
-      // Only original tones need wave data fetched
-      const totalSteps = originalSlots.length + 1; // fetches + write step
-
-      // Set initial progress immediately so the progress bar renders
-      setExportPatchProgress({
-        currentStep: 1, totalSteps,
-        stepLabel: originalSlots.length > 0
-          ? `Fetching tone ${memoryLayout.formatToneSlot(originalSlots[0])}`
-          : 'Writing files to library',
-        bytesSent: 0, bytesTotal: 0,
-        bytesSentAllSteps: 0, bytesTotalAllSteps: 0,
-      });
-
-      // Fetch wave data for original tones only
+      // Phase 3: fetch wave data for every original tone. Each fetch
+      // is its own step in the log; byte progress fills the active
+      // row's bar in real time.
       const bundleTones: PatchBundleTone[] = [];
       let completedWaveBytes = 0;
       let estimatedTotalBytes = 0;
 
       for (let i = 0; i < originalSlots.length; i++) {
         const slot = originalSlots[i];
-        const tone = tones[slot]!;
+        const tone = fetchedTones.get(slot)!;
+        stepCounter += 1;
+        const myStep = stepCounter;
 
         const waveData = await client.requestWaveData(
           slot,
@@ -367,8 +521,8 @@ export function useLibraryExport({
               estimatedTotalBytes = completedWaveBytes + total + (total * (originalSlots.length - i - 1));
             }
             setExportPatchProgress({
-              currentStep: i + 1,
-              totalSteps,
+              currentStep: myStep,
+              totalSteps: myStep + (originalSlots.length - i - 1) + 1,
               stepLabel: `Fetching tone ${memoryLayout.formatToneSlot(slot)}`,
               bytesSent: received,
               bytesTotal: total,
@@ -382,16 +536,20 @@ export function useLibraryExport({
         bundleTones.push({ slot, tone, waveData });
       }
 
-      // Add sub-tones without wave data — they reference the original tone's WAV
+      // Add sub-tones without wave data — they reference the
+      // original tone's WAV in the exported bundle.
       for (const slot of subToneSlots) {
-        const tone = tones[slot]!;
+        const tone = fetchedTones.get(slot)!;
         bundleTones.push({ slot, tone });
       }
 
+      // Phase 4 step counter bump for the write phase.
+      stepCounter += 1;
+
       // Final step: write to library
       setExportPatchProgress({
-        currentStep: totalSteps,
-        totalSteps: totalSteps,
+        currentStep: stepCounter,
+        totalSteps: stepCounter,
         stepLabel: 'Writing files to library',
         bytesSent: 0,
         bytesTotal: 0,
@@ -406,13 +564,16 @@ export function useLibraryExport({
         patchName,
         () => {
           // Writing is fast — keep progress at final step
-        }
+        },
+        // See tone-export sibling — targetPath threads through from the
+        // drop site so the bundle lands in the operator-targeted folder.
+        exportPatchDialog.targetPath ?? [],
       );
 
       // Final state: complete
       setExportPatchProgress({
-        currentStep: totalSteps,
-        totalSteps: totalSteps,
+        currentStep: stepCounter,
+        totalSteps: stepCounter,
         stepLabel: 'Export complete',
         bytesSent: 0,
         bytesTotal: 0,
@@ -420,7 +581,10 @@ export function useLibraryExport({
         bytesTotalAllSteps: completedWaveBytes,
       });
 
-      // Refresh individual patches list
+      // Refresh the library tree end-to-end so the newly exported
+      // patch surfaces without the operator hitting the refresh icon.
+      // See the tone-export sibling above for the rationale.
+      await handleRefreshLibrary();
       const updatedPatches = await listIndividualPatches(libraryHandle);
       setIndividualPatches(updatedPatches);
     } catch (err) {
@@ -431,7 +595,209 @@ export function useLibraryExport({
     } finally {
       setIsExporting(false);
     }
-  }, [libraryHandle, clientRef, exportPatchDialog, tones, setIndividualPatches]);
+  }, [libraryHandle, clientRef, exportPatchDialog, tones, setIndividualPatches, handleRefreshLibrary, memoryLayout]);
+
+  // Batch export — single entry point for both tone and patch batches.
+  // Loops the items declared in the current `batchExportDialog` serially,
+  // calling the same library helpers (`exportToneToDirectory` /
+  // `exportPatchToDirectory`) as the single-item flows. Progress is
+  // surfaced via `batchExportProgress` as a single step-per-item stream
+  // (each item is one row in the SteppedProgressDrawer's log) — the
+  // per-patch sub-steps (resolve / fetch / write) collapse to a single
+  // "Exporting patch X" row so the drawer doesn't grow unbounded.
+  const handleBatchExport = useCallback(async () => {
+    if (!batchExportDialog) {
+      throw new Error('No batch is queued for export');
+    }
+    if (!clientRef.current || !libraryHandle) {
+      throw new Error('Device or library not connected');
+    }
+    const { kind, items, targetPath } = batchExportDialog;
+    const client = clientRef.current;
+
+    setIsExporting(true);
+    setBatchExportError(null);
+
+    try {
+      let completedBytes = 0;
+      let estimatedTotalBytes = 0;
+
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        const stepHeader: OperationProgress = {
+          currentStep: i + 1,
+          totalSteps: items.length,
+          stepLabel: kind === 'tone'
+            ? `Exporting tone ${item.slotLabel}: ${item.name}`
+            : `Exporting patch ${item.slotLabel}: ${item.name}`,
+          bytesSent: 0,
+          bytesTotal: 0,
+          bytesSentAllSteps: completedBytes,
+          bytesTotalAllSteps: estimatedTotalBytes,
+        };
+        setBatchExportProgress(stepHeader);
+
+        if (kind === 'tone') {
+          const tone = tones[item.index];
+          if (!tone) {
+            throw new Error(`Tone at ${item.slotLabel} is no longer loaded`);
+          }
+          const waveData = await client.requestWaveData(
+            item.index,
+            (received, total) => {
+              if (estimatedTotalBytes === 0 || received === 0) {
+                estimatedTotalBytes = completedBytes + total + (total * (items.length - i - 1));
+              }
+              setBatchExportProgress({
+                ...stepHeader,
+                bytesSent: received,
+                bytesTotal: total,
+                bytesSentAllSteps: completedBytes + received,
+                bytesTotalAllSteps: estimatedTotalBytes,
+              });
+            },
+          );
+          await exportToneToDirectory(
+            libraryHandle,
+            { ...tone, name: item.name },
+            waveData,
+            item.name,
+            () => {},
+            targetPath,
+          );
+          completedBytes += waveData.data.length;
+        } else {
+          // Patch batch — resolve dependencies, fetch waves, then write.
+          // The per-patch sub-steps collapse into the single step header
+          // above; only the final "All N patches exported" surfaces in
+          // the step log. Mirrors handleExportPatch's structure with the
+          // dialog-state plumbing stripped out.
+          const patch = patches[item.index];
+          if (!patch) {
+            throw new Error(`Patch at ${item.slotLabel} is no longer loaded`);
+          }
+          const referencedSlots = getPatchToneDependencies(patch);
+          const fetchedTones = new Map<number, SamplerTone>();
+
+          const resolveTone = async (slot: number): Promise<SamplerTone> => {
+            const cached = fetchedTones.get(slot);
+            if (cached) return cached;
+            const existing = tones[slot];
+            if (existing) {
+              fetchedTones.set(slot, existing);
+              return existing;
+            }
+            const fetched = await client.requestToneData(slot);
+            if (!fetched) {
+              throw new Error(
+                `Device returned no data for tone ${memoryLayout.formatToneSlot(slot)} ` +
+                  `referenced by patch ${item.slotLabel}.`,
+              );
+            }
+            fetchedTones.set(slot, fetched);
+            return fetched;
+          };
+
+          const originalSlotSet = new Set<number>();
+          const subToneSlots: number[] = [];
+          for (const slot of referencedSlots) {
+            const t = await resolveTone(slot);
+            if (toneHasWaveData(t)) {
+              originalSlotSet.add(slot);
+            } else {
+              subToneSlots.push(slot);
+            }
+          }
+          for (const slot of subToneSlots) {
+            const t = fetchedTones.get(slot)!;
+            if (!originalSlotSet.has(t.sourceTone)) {
+              await resolveTone(t.sourceTone);
+              originalSlotSet.add(t.sourceTone);
+            }
+          }
+          const originalSlots = Array.from(originalSlotSet).sort((a, b) => a - b);
+
+          const bundleTones: PatchBundleTone[] = [];
+          let patchWaveBytes = 0;
+          for (const slot of originalSlots) {
+            const t = fetchedTones.get(slot)!;
+            const waveData = await client.requestWaveData(slot, (received, total) => {
+              if (estimatedTotalBytes === 0 || received === 0) {
+                // Rough estimate: assume each remaining patch's wave footprint
+                // is similar to what we've measured so far. The estimate
+                // self-corrects on every received-bytes callback.
+                estimatedTotalBytes = completedBytes + patchWaveBytes + total
+                  + (total * (items.length - i - 1) * Math.max(1, originalSlots.length));
+              }
+              setBatchExportProgress({
+                ...stepHeader,
+                bytesSent: received,
+                bytesTotal: total,
+                bytesSentAllSteps: completedBytes + patchWaveBytes + received,
+                bytesTotalAllSteps: estimatedTotalBytes,
+              });
+            });
+            patchWaveBytes += waveData.data.length;
+            bundleTones.push({ slot, tone: t, waveData });
+          }
+          for (const slot of subToneSlots) {
+            const t = fetchedTones.get(slot)!;
+            bundleTones.push({ slot, tone: t });
+          }
+          await exportPatchToDirectory(
+            libraryHandle,
+            { ...patch, common: { ...patch.common, name: item.name } },
+            bundleTones,
+            item.name,
+            () => {},
+            targetPath,
+          );
+          completedBytes += patchWaveBytes;
+        }
+      }
+
+      // Final completion step — emits a clean "Export complete" row
+      // in the step log so the drawer transitions to Done state.
+      setBatchExportProgress({
+        currentStep: items.length,
+        totalSteps: items.length,
+        stepLabel: 'Export complete',
+        bytesSent: 0,
+        bytesTotal: 0,
+        bytesSentAllSteps: completedBytes,
+        bytesTotalAllSteps: completedBytes,
+      });
+
+      // Single refresh after the loop — see UseLibraryExportOptions.handleRefreshLibrary
+      // docstring for why per-item refresh is wrong (O(N²) tree work + cross-category
+      // state churn the operator sees as flicker).
+      await handleRefreshLibrary();
+      if (kind === 'tone') {
+        const updatedTones = await listIndividualTones(libraryHandle);
+        setIndividualTones(updatedTones);
+      } else {
+        const updatedPatches = await listIndividualPatches(libraryHandle);
+        setIndividualPatches(updatedPatches);
+      }
+    } catch (err) {
+      console.error('[useLibraryExport] Batch export failed:', err);
+      const message = err instanceof Error ? err.message : 'Batch export failed';
+      setBatchExportError(message);
+      throw err;
+    } finally {
+      setIsExporting(false);
+    }
+  }, [
+    batchExportDialog,
+    clientRef,
+    libraryHandle,
+    tones,
+    patches,
+    setIndividualTones,
+    setIndividualPatches,
+    handleRefreshLibrary,
+    memoryLayout,
+  ]);
 
   return {
     exportToneDialog,
@@ -440,14 +806,19 @@ export function useLibraryExport({
     exportPatchDialog,
     exportPatchProgress,
     exportPatchError,
+    batchExportDialog,
+    batchExportProgress,
+    batchExportError,
     isExporting,
     handleDropDeviceTone,
     handleDropDevicePatch,
     handleExportTone,
     handleExportPatch,
+    handleBatchExport,
     openExportToneDialog,
     openExportPatchDialog,
     closeExportToneDialog,
     closeExportPatchDialog,
+    closeBatchExportDialog,
   };
 }

--- a/modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts
+++ b/modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts
@@ -793,15 +793,20 @@ export function useLibraryExport({
       // Final completion step — emits a "complete" row that triggers
       // the drawer to transition to Done state via isOperationComplete.
       // Label varies by outcome so the step log's last row reads as a
-      // summary instead of a redundant "Export complete".
+      // summary instead of a redundant "Export complete". Uses
+      // currentStep = items.length + 1 so the summary lands in its own
+      // row instead of overwriting the last item's row (otherwise the
+      // LAST item's per-step error message is clobbered before the
+      // operator can read it — caught by D-LIB-31's all-failed path
+      // where slot N's error was missing from the step log).
       const finalLabel = failures.size === 0
         ? 'Export complete'
         : successCount === 0
           ? `Batch failed — all ${items.length} items errored`
           : `Exported ${successCount} of ${items.length} (${failures.size} failed)`;
       setBatchExportProgress({
-        currentStep: items.length,
-        totalSteps: items.length,
+        currentStep: items.length + 1,
+        totalSteps: items.length + 1,
         stepLabel: finalLabel,
         bytesSent: 0,
         bytesTotal: 0,

--- a/modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts
+++ b/modules/roland-sxx0-editor/src/hooks/useLibraryExport.ts
@@ -107,6 +107,12 @@ interface UseLibraryExportResult {
   batchExportDialog: BatchExportDialogState | null;
   batchExportProgress: OperationProgress | undefined;
   batchExportError: string | null;
+  /** Per-item failure map for the in-flight batch, keyed by step
+   *  number (1-based, matching `OperationProgress.currentStep`). The
+   *  batch loop continues on per-item errors and records them here;
+   *  the drawer reads this to mark failed rows in the step log
+   *  alongside the successful ones. */
+  batchExportFailures: Map<number, string>;
 
   // Shared
   isExporting: boolean;
@@ -168,6 +174,14 @@ export function useLibraryExport({
   const [batchExportDialog, setBatchExportDialog] = useState<BatchExportDialogState | null>(null);
   const [batchExportProgress, setBatchExportProgress] = useState<OperationProgress | undefined>(undefined);
   const [batchExportError, setBatchExportError] = useState<string | null>(null);
+  // Per-item failures keyed by step number (1-based, matches
+  // OperationProgress.currentStep). Populated by handleBatchExport
+  // when an item throws; the loop continues to the next item rather
+  // than aborting. The drawer reads this and passes it to
+  // useStepHistory so the step log shows ✗ on each failed row + ✓
+  // on the successes, instead of the old behavior where one failure
+  // aborted the entire batch.
+  const [batchExportFailures, setBatchExportFailures] = useState<Map<number, string>>(() => new Map());
 
   // Shared
   const [isExporting, setIsExporting] = useState(false);
@@ -195,6 +209,7 @@ export function useLibraryExport({
       setBatchExportDialog(null);
       setBatchExportProgress(undefined);
       setBatchExportError(null);
+      setBatchExportFailures(new Map());
     }
   }, [isExporting]);
 
@@ -598,13 +613,15 @@ export function useLibraryExport({
   }, [libraryHandle, clientRef, exportPatchDialog, tones, setIndividualPatches, handleRefreshLibrary, memoryLayout]);
 
   // Batch export — single entry point for both tone and patch batches.
-  // Loops the items declared in the current `batchExportDialog` serially,
-  // calling the same library helpers (`exportToneToDirectory` /
-  // `exportPatchToDirectory`) as the single-item flows. Progress is
-  // surfaced via `batchExportProgress` as a single step-per-item stream
-  // (each item is one row in the SteppedProgressDrawer's log) — the
-  // per-patch sub-steps (resolve / fetch / write) collapse to a single
-  // "Exporting patch X" row so the drawer doesn't grow unbounded.
+  // Loops the items declared in the current `batchExportDialog` serially.
+  // Each item runs inside its own try/catch: a per-item failure (device
+  // returned no data for a slot, write failed, network blip on a single
+  // wave fetch, etc.) records the error in `batchExportFailures` and
+  // continues to the next item. The whole batch only ends in an error
+  // state if EVERY item failed; partial success still refreshes the
+  // library and shows a "N of M exported (K failed)" summary so the
+  // operator sees what landed and what didn't. This replaces the prior
+  // throw-the-loop behavior which made one bad slot ruin a 20-item drag.
   const handleBatchExport = useCallback(async () => {
     if (!batchExportDialog) {
       throw new Error('No batch is queued for export');
@@ -617,6 +634,8 @@ export function useLibraryExport({
 
     setIsExporting(true);
     setBatchExportError(null);
+    setBatchExportFailures(new Map());
+    const failures = new Map<number, string>();
 
     try {
       let completedBytes = 0;
@@ -637,150 +656,185 @@ export function useLibraryExport({
         };
         setBatchExportProgress(stepHeader);
 
-        if (kind === 'tone') {
-          const tone = tones[item.index];
-          if (!tone) {
-            throw new Error(`Tone at ${item.slotLabel} is no longer loaded`);
-          }
-          const waveData = await client.requestWaveData(
-            item.index,
-            (received, total) => {
-              if (estimatedTotalBytes === 0 || received === 0) {
-                estimatedTotalBytes = completedBytes + total + (total * (items.length - i - 1));
+        try {
+          if (kind === 'tone') {
+            const tone = tones[item.index];
+            if (!tone) {
+              throw new Error(`Tone at ${item.slotLabel} is no longer loaded`);
+            }
+            const waveData = await client.requestWaveData(
+              item.index,
+              (received, total) => {
+                if (estimatedTotalBytes === 0 || received === 0) {
+                  estimatedTotalBytes = completedBytes + total + (total * (items.length - i - 1));
+                }
+                setBatchExportProgress({
+                  ...stepHeader,
+                  bytesSent: received,
+                  bytesTotal: total,
+                  bytesSentAllSteps: completedBytes + received,
+                  bytesTotalAllSteps: estimatedTotalBytes,
+                });
+              },
+            );
+            await exportToneToDirectory(
+              libraryHandle,
+              { ...tone, name: item.name },
+              waveData,
+              item.name,
+              () => {},
+              targetPath,
+            );
+            completedBytes += waveData.data.length;
+          } else {
+            // Patch batch — resolve dependencies, fetch waves, then write.
+            // The per-patch sub-steps collapse into the single step header
+            // above; only the final "All N patches exported" surfaces in
+            // the step log. Mirrors handleExportPatch's structure with the
+            // dialog-state plumbing stripped out.
+            const patch = patches[item.index];
+            if (!patch) {
+              throw new Error(`Patch at ${item.slotLabel} is no longer loaded`);
+            }
+            const referencedSlots = getPatchToneDependencies(patch);
+            const fetchedTones = new Map<number, SamplerTone>();
+
+            const resolveTone = async (slot: number): Promise<SamplerTone> => {
+              const cached = fetchedTones.get(slot);
+              if (cached) return cached;
+              const existing = tones[slot];
+              if (existing) {
+                fetchedTones.set(slot, existing);
+                return existing;
               }
-              setBatchExportProgress({
-                ...stepHeader,
-                bytesSent: received,
-                bytesTotal: total,
-                bytesSentAllSteps: completedBytes + received,
-                bytesTotalAllSteps: estimatedTotalBytes,
-              });
-            },
-          );
-          await exportToneToDirectory(
-            libraryHandle,
-            { ...tone, name: item.name },
-            waveData,
-            item.name,
-            () => {},
-            targetPath,
-          );
-          completedBytes += waveData.data.length;
-        } else {
-          // Patch batch — resolve dependencies, fetch waves, then write.
-          // The per-patch sub-steps collapse into the single step header
-          // above; only the final "All N patches exported" surfaces in
-          // the step log. Mirrors handleExportPatch's structure with the
-          // dialog-state plumbing stripped out.
-          const patch = patches[item.index];
-          if (!patch) {
-            throw new Error(`Patch at ${item.slotLabel} is no longer loaded`);
-          }
-          const referencedSlots = getPatchToneDependencies(patch);
-          const fetchedTones = new Map<number, SamplerTone>();
-
-          const resolveTone = async (slot: number): Promise<SamplerTone> => {
-            const cached = fetchedTones.get(slot);
-            if (cached) return cached;
-            const existing = tones[slot];
-            if (existing) {
-              fetchedTones.set(slot, existing);
-              return existing;
-            }
-            const fetched = await client.requestToneData(slot);
-            if (!fetched) {
-              throw new Error(
-                `Device returned no data for tone ${memoryLayout.formatToneSlot(slot)} ` +
-                  `referenced by patch ${item.slotLabel}.`,
-              );
-            }
-            fetchedTones.set(slot, fetched);
-            return fetched;
-          };
-
-          const originalSlotSet = new Set<number>();
-          const subToneSlots: number[] = [];
-          for (const slot of referencedSlots) {
-            const t = await resolveTone(slot);
-            if (toneHasWaveData(t)) {
-              originalSlotSet.add(slot);
-            } else {
-              subToneSlots.push(slot);
-            }
-          }
-          for (const slot of subToneSlots) {
-            const t = fetchedTones.get(slot)!;
-            if (!originalSlotSet.has(t.sourceTone)) {
-              await resolveTone(t.sourceTone);
-              originalSlotSet.add(t.sourceTone);
-            }
-          }
-          const originalSlots = Array.from(originalSlotSet).sort((a, b) => a - b);
-
-          const bundleTones: PatchBundleTone[] = [];
-          let patchWaveBytes = 0;
-          for (const slot of originalSlots) {
-            const t = fetchedTones.get(slot)!;
-            const waveData = await client.requestWaveData(slot, (received, total) => {
-              if (estimatedTotalBytes === 0 || received === 0) {
-                // Rough estimate: assume each remaining patch's wave footprint
-                // is similar to what we've measured so far. The estimate
-                // self-corrects on every received-bytes callback.
-                estimatedTotalBytes = completedBytes + patchWaveBytes + total
-                  + (total * (items.length - i - 1) * Math.max(1, originalSlots.length));
+              const fetched = await client.requestToneData(slot);
+              if (!fetched) {
+                throw new Error(
+                  `Device returned no data for tone ${memoryLayout.formatToneSlot(slot)} ` +
+                    `referenced by patch ${item.slotLabel}.`,
+                );
               }
-              setBatchExportProgress({
-                ...stepHeader,
-                bytesSent: received,
-                bytesTotal: total,
-                bytesSentAllSteps: completedBytes + patchWaveBytes + received,
-                bytesTotalAllSteps: estimatedTotalBytes,
+              fetchedTones.set(slot, fetched);
+              return fetched;
+            };
+
+            const originalSlotSet = new Set<number>();
+            const subToneSlots: number[] = [];
+            for (const slot of referencedSlots) {
+              const t = await resolveTone(slot);
+              if (toneHasWaveData(t)) {
+                originalSlotSet.add(slot);
+              } else {
+                subToneSlots.push(slot);
+              }
+            }
+            for (const slot of subToneSlots) {
+              const t = fetchedTones.get(slot)!;
+              if (!originalSlotSet.has(t.sourceTone)) {
+                await resolveTone(t.sourceTone);
+                originalSlotSet.add(t.sourceTone);
+              }
+            }
+            const originalSlots = Array.from(originalSlotSet).sort((a, b) => a - b);
+
+            const bundleTones: PatchBundleTone[] = [];
+            let patchWaveBytes = 0;
+            for (const slot of originalSlots) {
+              const t = fetchedTones.get(slot)!;
+              const waveData = await client.requestWaveData(slot, (received, total) => {
+                if (estimatedTotalBytes === 0 || received === 0) {
+                  // Rough estimate: assume each remaining patch's wave footprint
+                  // is similar to what we've measured so far. The estimate
+                  // self-corrects on every received-bytes callback.
+                  estimatedTotalBytes = completedBytes + patchWaveBytes + total
+                    + (total * (items.length - i - 1) * Math.max(1, originalSlots.length));
+                }
+                setBatchExportProgress({
+                  ...stepHeader,
+                  bytesSent: received,
+                  bytesTotal: total,
+                  bytesSentAllSteps: completedBytes + patchWaveBytes + received,
+                  bytesTotalAllSteps: estimatedTotalBytes,
+                });
               });
-            });
-            patchWaveBytes += waveData.data.length;
-            bundleTones.push({ slot, tone: t, waveData });
+              patchWaveBytes += waveData.data.length;
+              bundleTones.push({ slot, tone: t, waveData });
+            }
+            for (const slot of subToneSlots) {
+              const t = fetchedTones.get(slot)!;
+              bundleTones.push({ slot, tone: t });
+            }
+            await exportPatchToDirectory(
+              libraryHandle,
+              { ...patch, common: { ...patch.common, name: item.name } },
+              bundleTones,
+              item.name,
+              () => {},
+              targetPath,
+            );
+            completedBytes += patchWaveBytes;
           }
-          for (const slot of subToneSlots) {
-            const t = fetchedTones.get(slot)!;
-            bundleTones.push({ slot, tone: t });
-          }
-          await exportPatchToDirectory(
-            libraryHandle,
-            { ...patch, common: { ...patch.common, name: item.name } },
-            bundleTones,
-            item.name,
-            () => {},
-            targetPath,
+        } catch (err) {
+          // Per-item failure — record + continue. Logged so the per-
+          // item cause is preserved beyond the in-drawer step log,
+          // which truncates long messages.
+          const message = err instanceof Error ? err.message : 'Item export failed';
+          console.error(
+            `[useLibraryExport] Batch item ${item.slotLabel} (${kind}) failed:`,
+            err,
           );
-          completedBytes += patchWaveBytes;
+          failures.set(i + 1, message);
+          setBatchExportFailures(new Map(failures));
         }
       }
 
-      // Final completion step — emits a clean "Export complete" row
-      // in the step log so the drawer transitions to Done state.
+      const successCount = items.length - failures.size;
+
+      // Final completion step — emits a "complete" row that triggers
+      // the drawer to transition to Done state via isOperationComplete.
+      // Label varies by outcome so the step log's last row reads as a
+      // summary instead of a redundant "Export complete".
+      const finalLabel = failures.size === 0
+        ? 'Export complete'
+        : successCount === 0
+          ? `Batch failed — all ${items.length} items errored`
+          : `Exported ${successCount} of ${items.length} (${failures.size} failed)`;
       setBatchExportProgress({
         currentStep: items.length,
         totalSteps: items.length,
-        stepLabel: 'Export complete',
+        stepLabel: finalLabel,
         bytesSent: 0,
         bytesTotal: 0,
         bytesSentAllSteps: completedBytes,
         bytesTotalAllSteps: completedBytes,
       });
 
-      // Single refresh after the loop — see UseLibraryExportOptions.handleRefreshLibrary
-      // docstring for why per-item refresh is wrong (O(N²) tree work + cross-category
-      // state churn the operator sees as flicker).
-      await handleRefreshLibrary();
-      if (kind === 'tone') {
-        const updatedTones = await listIndividualTones(libraryHandle);
-        setIndividualTones(updatedTones);
-      } else {
-        const updatedPatches = await listIndividualPatches(libraryHandle);
-        setIndividualPatches(updatedPatches);
+      // Refresh only if at least one item landed — a fully-failed
+      // batch wrote nothing, so the tree re-scan would be wasted work.
+      if (successCount > 0) {
+        await handleRefreshLibrary();
+        if (kind === 'tone') {
+          const updatedTones = await listIndividualTones(libraryHandle);
+          setIndividualTones(updatedTones);
+        } else {
+          const updatedPatches = await listIndividualPatches(libraryHandle);
+          setIndividualPatches(updatedPatches);
+        }
+      }
+
+      // Surface the all-failed case as a top-level error so the drawer
+      // chrome shows the Close button instead of Done — partial success
+      // does NOT set this; partial is a "complete with warnings" state
+      // visible via per-step failure rows + the summary label above.
+      if (successCount === 0) {
+        setBatchExportError(`All ${items.length} items failed to export`);
       }
     } catch (err) {
-      console.error('[useLibraryExport] Batch export failed:', err);
+      // Reaches here only on a pre-loop precondition failure (no client,
+      // no library handle, etc.) — per-item throws are caught inside
+      // the loop and recorded in `failures`. Surface as a top-level
+      // error so the drawer doesn't hang in an indeterminate state.
+      console.error('[useLibraryExport] Batch export precondition failure:', err);
       const message = err instanceof Error ? err.message : 'Batch export failed';
       setBatchExportError(message);
       throw err;
@@ -809,6 +863,7 @@ export function useLibraryExport({
     batchExportDialog,
     batchExportProgress,
     batchExportError,
+    batchExportFailures,
     isExporting,
     handleDropDeviceTone,
     handleDropDevicePatch,

--- a/modules/roland-sxx0-editor/src/hooks/useRolandLibraryStrategy.ts
+++ b/modules/roland-sxx0-editor/src/hooks/useRolandLibraryStrategy.ts
@@ -20,6 +20,7 @@ import {
   renameDirectory,
   deleteSet,
   renameSet,
+  moveItem as moveLibraryItem,
 } from '@/lib/library-service';
 import type { RolandPageSelection } from '@/pages/LibraryPage';
 
@@ -106,6 +107,43 @@ export function useRolandLibraryStrategy({
         return { handled: true };
       }
       return { handled: false };
+    },
+
+    async moveItem(categoryId: string, node: TreeNode, targetPath: string[]): Promise<StrategyResult> {
+      if (!libraryHandle) return { handled: false };
+      // Common-area categories live under library/common/samples — the
+      // shared hook's common-area moveItem is correct for those.
+      if (categoryId === 'samples' || categoryId === 'programs') {
+        return { handled: false };
+      }
+      const sourcePath = getNodePath(node);
+      const itemName = getNodeName(node);
+      await moveLibraryItem(
+        libraryHandle,
+        toLibraryCategory(categoryId),
+        sourcePath,
+        itemName,
+        targetPath,
+      );
+      // If the moved item was the page-level selection, clear it.
+      // The selection's `path` field still points to the OLD parent
+      // (e.g. ['DRUMS']) after the move; the preview pane's load
+      // useEffect would then re-attempt `loadIndividualPatch(handle,
+      // name, oldPath)` and the file-system-access call would throw
+      // "file or directory could not be found" — visible to the
+      // operator as a "FAILED TO LOAD" body even though the move
+      // itself succeeded. Mirrors the same clear-on-mutation guard
+      // that `deleteItem` above uses for the delete case.
+      const samePath = (a: string[] | undefined, b: string[]) =>
+        (a ?? []).length === b.length && (a ?? []).every((seg, i) => seg === b[i]);
+      if (
+        selection &&
+        ((selection.type === 'individualTone' && node.type === 'tone' && selection.name === itemName && samePath(selection.path, sourcePath)) ||
+          (selection.type === 'individualPatch' && node.type === 'patch' && selection.name === itemName && samePath(selection.path, sourcePath)))
+      ) {
+        setSelection(null);
+      }
+      return { handled: true };
     },
 
     async renameItem(categoryId: string, node: TreeNode, newName: string): Promise<StrategyResult> {

--- a/modules/roland-sxx0-editor/src/hooks/useStepHistory.ts
+++ b/modules/roland-sxx0-editor/src/hooks/useStepHistory.ts
@@ -1,0 +1,116 @@
+/**
+ * useStepHistory
+ *
+ * Converts a live {@link OperationProgress} stream into a growing
+ * {@link ProgressStep}[] log suitable for the v3 stepped-progress UI.
+ *
+ * `OperationProgress` carries only the CURRENT step's bytes + label;
+ * the step-log view needs the HISTORY. This hook accumulates: each
+ * time a new `currentStep` arrives, the previous step is marked
+ * complete and the new step joins the list as active. On success
+ * every step flips to complete; on error the last in-flight step
+ * flips to failed and carries the error message.
+ *
+ * The output is safe to render with `StepRow` from editor-core or
+ * with the shared `ac-step-*` CSS classes from
+ * `editor-core/src/design/library.css`.
+ */
+
+import { useEffect, useState } from 'react';
+import type { ProgressStep, StepStatus } from '@audiocontrol/editor-core';
+import { type OperationProgress, formatBytes } from '@/types/import-operation';
+
+interface UseStepHistoryOptions {
+  progress: OperationProgress | undefined;
+  isComplete: boolean;
+  /** Coalesced local + operation error. `undefined` and `null` both mean
+   *  "no error" so the dialog can pass `localError ?? operationError`
+   *  directly without an extra `?? null` coercion at every call site. */
+  error: string | null | undefined;
+}
+
+export function useStepHistory({
+  progress,
+  isComplete,
+  error,
+}: UseStepHistoryOptions): ProgressStep[] {
+  const [steps, setSteps] = useState<ProgressStep[]>([]);
+
+  // Reset on idle (no progress, no completion, no error).
+  useEffect(() => {
+    if (!progress && !isComplete && !error) {
+      setSteps([]);
+    }
+  }, [progress, isComplete, error]);
+
+  // Append or update the current step from incoming progress.
+  useEffect(() => {
+    if (!progress) return;
+    setSteps((prev) => {
+      const id = `step-${progress.currentStep}`;
+      const stepProgress =
+        progress.bytesTotal > 0
+          ? Math.round((progress.bytesSent / progress.bytesTotal) * 100)
+          : undefined;
+      const stepDetail =
+        progress.bytesTotal > 0
+          ? `${formatBytes(progress.bytesSent)} / ${formatBytes(progress.bytesTotal)}`
+          : undefined;
+      const completed = prev.map((s) =>
+        s.id === id
+          ? s
+          : { ...s, status: 'complete' as StepStatus, progress: undefined },
+      );
+      const existing = completed.find((s) => s.id === id);
+      const current: ProgressStep = {
+        id,
+        label: progress.stepLabel,
+        status: 'active',
+        progress: stepProgress,
+        detail: stepDetail,
+      };
+      return existing
+        ? completed.map((s) => (s.id === id ? current : s))
+        : [...completed, current];
+    });
+  }, [progress]);
+
+  // Mark every step complete when the operation finishes cleanly.
+  useEffect(() => {
+    if (isComplete && !error) {
+      setSteps((prev) =>
+        prev.map((s) => ({
+          ...s,
+          status: 'complete' as StepStatus,
+          progress: undefined,
+        })),
+      );
+    }
+  }, [isComplete, error]);
+
+  // Mark the last in-flight step as failed when an error surfaces.
+  // If the error fires before any step has started (precondition
+  // miss, BUG-001 shape), emit a single failed row so the operator
+  // sees the reason instead of a silent close.
+  useEffect(() => {
+    if (!error) return;
+    setSteps((prev) =>
+      prev.length > 0
+        ? prev.map((s, i, arr) =>
+            i === arr.length - 1
+              ? { ...s, status: 'failed' as StepStatus, error }
+              : s,
+          )
+        : [
+            {
+              id: 'precondition',
+              label: 'Export failed',
+              status: 'failed' as StepStatus,
+              error,
+            },
+          ],
+    );
+  }, [error]);
+
+  return steps;
+}

--- a/modules/roland-sxx0-editor/src/hooks/useStepHistory.ts
+++ b/modules/roland-sxx0-editor/src/hooks/useStepHistory.ts
@@ -27,13 +27,34 @@ interface UseStepHistoryOptions {
    *  "no error" so the dialog can pass `localError ?? operationError`
    *  directly without an extra `?? null` coercion at every call site. */
   error: string | null | undefined;
+  /** Per-step failures keyed by `currentStep` (1-based, matches
+   *  `OperationProgress.currentStep`). Used by the batch-export flow
+   *  to mark individual items as failed in the step log while the
+   *  overall operation continues to the next item — without this, the
+   *  hook can only flag the LAST in-flight step as failed (via the
+   *  top-level `error`), which is wrong for continue-on-error batches
+   *  where step N failed but step N+1 succeeded. Keys not present in
+   *  the map are treated as successes when their step transitions out
+   *  of "active". */
+  stepErrors?: Map<number, string>;
 }
 
 export function useStepHistory({
   progress,
   isComplete,
   error,
+  stepErrors,
 }: UseStepHistoryOptions): ProgressStep[] {
+  const stepNumberOf = (id: string): number => {
+    const n = parseInt(id.replace('step-', ''), 10);
+    return Number.isFinite(n) ? n : -1;
+  };
+  const settledStatus = (id: string): { status: StepStatus; error?: string } => {
+    const failure = stepErrors?.get(stepNumberOf(id));
+    return failure
+      ? { status: 'failed', error: failure }
+      : { status: 'complete' };
+  };
   const [steps, setSteps] = useState<ProgressStep[]>([]);
 
   // Reset on idle (no progress, no completion, no error).
@@ -56,11 +77,11 @@ export function useStepHistory({
         progress.bytesTotal > 0
           ? `${formatBytes(progress.bytesSent)} / ${formatBytes(progress.bytesTotal)}`
           : undefined;
-      const completed = prev.map((s) =>
-        s.id === id
-          ? s
-          : { ...s, status: 'complete' as StepStatus, progress: undefined },
-      );
+      const completed = prev.map((s) => {
+        if (s.id === id) return s;
+        const settled = settledStatus(s.id);
+        return { ...s, status: settled.status, error: settled.error, progress: undefined };
+      });
       const existing = completed.find((s) => s.id === id);
       const current: ProgressStep = {
         id,
@@ -75,18 +96,26 @@ export function useStepHistory({
     });
   }, [progress]);
 
-  // Mark every step complete when the operation finishes cleanly.
+  // Mark every step complete (or failed-per-stepErrors) when the
+  // operation finishes cleanly. The single-item flows never populate
+  // stepErrors so this collapses to the prior "all complete" behavior;
+  // the batch flow uses it to freeze per-item failures in the final
+  // step log alongside the successful items.
   useEffect(() => {
     if (isComplete && !error) {
       setSteps((prev) =>
-        prev.map((s) => ({
-          ...s,
-          status: 'complete' as StepStatus,
-          progress: undefined,
-        })),
+        prev.map((s) => {
+          const settled = settledStatus(s.id);
+          return {
+            ...s,
+            status: settled.status,
+            error: settled.error,
+            progress: undefined,
+          };
+        }),
       );
     }
-  }, [isComplete, error]);
+  }, [isComplete, error, stepErrors]);
 
   // Mark the last in-flight step as failed when an error surfaces.
   // If the error fires before any step has started (precondition

--- a/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
+++ b/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
@@ -112,8 +112,24 @@ export function LibraryPage() {
   } = useRolandSelectionMapping(libraryHandle);
 
   useEffect(() => {
-    if (!adapter) { clientRef.current = null; return; }
+    if (!adapter) {
+      clientRef.current = null;
+      if (import.meta.env.DEV) {
+        (window as unknown as { __samplerClient?: SamplerClientInterface | null }).__samplerClient = null;
+      }
+      return;
+    }
     clientRef.current = config.createClient(adapter, { deviceId });
+    // Dev-only test seam — wiring tests monkeypatch `requestWaveData`
+    // here to selectively succeed or throw per slot index so the
+    // batch-export continue-on-error path (D-LIB-31) can be exercised
+    // without a fixture that selectively fails. Mirrors the existing
+    // `__deviceDataStore` seam used by `seedDeviceTone`. Production
+    // builds skip the assignment via the import.meta.env.DEV gate so
+    // the surface is never present in shipped bundles.
+    if (import.meta.env.DEV) {
+      (window as unknown as { __samplerClient?: SamplerClientInterface | null }).__samplerClient = clientRef.current;
+    }
   }, [adapter, deviceId]);
 
   const setToneForHook = useCallback((index: number, tone: SamplerTone) => setTone(index, tone, totalTones), [setTone, totalTones]);

--- a/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
+++ b/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
@@ -625,6 +625,7 @@ export function LibraryPage() {
         kind={exportOps.batchExportDialog?.kind ?? 'tone'}
         items={exportOps.batchExportDialog?.items ?? []}
         targetPath={exportOps.batchExportDialog?.targetPath ?? []}
+        failures={exportOps.batchExportFailures}
         onExport={exportOps.handleBatchExport}
         isOperating={exportOps.isExporting}
         progress={exportOps.batchExportProgress}

--- a/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
+++ b/modules/roland-sxx0-editor/src/pages/LibraryPage.tsx
@@ -10,10 +10,12 @@
  */
 
 import { useCallback, useEffect, useRef, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useMidiStore } from '@/stores/midiStore';
 import { useDeviceDataStore } from '@/stores/deviceDataStore';
 import { useDeviceConfig } from '@/context/DeviceConfigContext';
 import { useLibraryStore } from '@/stores/libraryStore';
+import { useEditorStore } from '@/stores/editorStore';
 import type { SamplerClientInterface, SamplerTone, SamplerPatch } from '@/core/midi/SamplerClient';
 import {
   useLibraryConnection, useErrorReporter, useLibraryOperations, LibraryConnectionUI, PluginLibraryBrowser,
@@ -32,6 +34,7 @@ import { SampleEditorDialog } from '@audiocontrol/sample-editor/ui';
 import { SampleChopperDialog } from '@audiocontrol/sample-chopper/ui';
 import { ExportToneDialog } from '@/components/library/ExportToneDialog';
 import { ExportPatchDialog } from '@/components/library/ExportPatchDialog';
+import { BatchExportDrawer } from '@/components/library/BatchExportDrawer';
 import { DEVICE_DRAG_MIME, type DeviceDragData } from '@/components/library/DeviceMemoryPanel';
 import {
   useImportSamples,
@@ -149,6 +152,7 @@ export function LibraryPage() {
 
   const exportOps = useLibraryExport({
     clientRef, libraryHandle, tones, patches, setIndividualTones, setIndividualPatches,
+    handleRefreshLibrary,
   });
 
   const importDialogs = useLibraryImportDialogs({
@@ -248,7 +252,7 @@ export function LibraryPage() {
   const handleExternalDrop = useCallback((
     categoryId: string,
     dataTransfer: DataTransfer,
-    _targetPath: string[],
+    targetPath: string[],
   ): boolean => {
     const raw = dataTransfer.getData(DEVICE_DRAG_MIME);
     if (!raw) return false;
@@ -263,9 +267,11 @@ export function LibraryPage() {
     // patches-section accepts patch drags. Mismatched drops fail loudly
     // (no silent fallback) because the user's intent isn't ambiguous —
     // dropping a tone on the patch section is most likely a mis-aim.
+    // targetPath threads through to the export dialog so a drop on a
+    // folder row writes into that folder instead of the section root.
     if (data.type === 'tone' && categoryId === 'tones') {
       try {
-        exportOps.handleDropDeviceTone(data);
+        exportOps.handleDropDeviceTone(data, targetPath);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to start tone export');
       }
@@ -273,7 +279,7 @@ export function LibraryPage() {
     }
     if (data.type === 'patch' && categoryId === 'patches') {
       try {
-        exportOps.handleDropDevicePatch(data);
+        exportOps.handleDropDevicePatch(data, targetPath);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to start patch export');
       }
@@ -393,6 +399,23 @@ export function LibraryPage() {
     loadingToneBank, loadingPatchBank, loadToneBank, loadPatchBank,
   ]);
 
+  const navigate = useNavigate();
+  // Device-memory preview affordances: Export-to-Library reuses the
+  // imperative `openExport*Dialog` so the same v3 SteppedProgressDrawer
+  // the drag-drop path opens is what the operator sees here. Edit-in-Editor
+  // pre-selects the slot in `editorStore` (so TonesPage / PatchesPage
+  // open on that slot) and routes via React Router under the active
+  // device segment (`/roland/<device>/editor/<page>`).
+  const editorBase = `/roland/${config.deviceType}/editor`;
+  const handleEditDeviceTone = useCallback((toneIndex: number) => {
+    useEditorStore.getState().selectTone(toneIndex);
+    navigate(`${editorBase}/tones`);
+  }, [editorBase, navigate]);
+  const handleEditDevicePatch = useCallback((patchIndex: number) => {
+    useEditorStore.getState().selectPatch(patchIndex);
+    navigate(`${editorBase}/patches`);
+  }, [editorBase, navigate]);
+
   const previewState = useMemo<PreviewPanelCustomState>(() => ({
     pageSelection: selection,
     deviceTones: tones,
@@ -406,7 +429,15 @@ export function LibraryPage() {
     onOpenInLoopEditor: (name: string, path?: string[]) => editorDialogs.handleOpenInLoopEditor(name, 'sample', path),
     onOpenInChopper: (name: string, path?: string[]) => editorDialogs.handleOpenInChopper(name, 'sample', path),
     onOpenInSampleEditor: (name: string, path?: string[]) => editorDialogs.handleOpenInSampleEditor(name, 'sample', path),
-  }), [selection, tones, patches, libraryHandle, importDialogs, editorDialogs]);
+    onExportDeviceTone: exportOps.openExportToneDialog,
+    onExportDevicePatch: exportOps.openExportPatchDialog,
+    onEditDeviceTone: handleEditDeviceTone,
+    onEditDevicePatch: handleEditDevicePatch,
+  }), [
+    selection, tones, patches, libraryHandle, importDialogs, editorDialogs,
+    exportOps.openExportToneDialog, exportOps.openExportPatchDialog,
+    handleEditDeviceTone, handleEditDevicePatch,
+  ]);
 
   const connectionSlot = (
     <LibraryConnectionUI
@@ -577,14 +608,27 @@ export function LibraryPage() {
       <ExportToneDialog
         open={!!exportOps.exportToneDialog} onOpenChange={(open) => { if (!open) exportOps.closeExportToneDialog(); }}
         tone={exportOps.exportToneDialog?.tone ?? null} toneIndex={exportOps.exportToneDialog?.toneIndex ?? 0}
+        targetPath={exportOps.exportToneDialog?.targetPath}
         onExport={exportOps.handleExportTone} isOperating={exportOps.isExporting}
         progress={exportOps.exportProgress} error={exportOps.exportError}
       />
       <ExportPatchDialog
         open={!!exportOps.exportPatchDialog} onOpenChange={(open) => { if (!open) exportOps.closeExportPatchDialog(); }}
         patch={exportOps.exportPatchDialog?.patch ?? null} patchIndex={exportOps.exportPatchDialog?.patchIndex ?? 0}
+        targetPath={exportOps.exportPatchDialog?.targetPath}
         onExport={exportOps.handleExportPatch} isOperating={exportOps.isExporting}
         progress={exportOps.exportPatchProgress} error={exportOps.exportPatchError}
+      />
+      <BatchExportDrawer
+        open={!!exportOps.batchExportDialog}
+        onOpenChange={(open) => { if (!open) exportOps.closeBatchExportDialog(); }}
+        kind={exportOps.batchExportDialog?.kind ?? 'tone'}
+        items={exportOps.batchExportDialog?.items ?? []}
+        targetPath={exportOps.batchExportDialog?.targetPath ?? []}
+        onExport={exportOps.handleBatchExport}
+        isOperating={exportOps.isExporting}
+        progress={exportOps.batchExportProgress}
+        error={exportOps.batchExportError}
       />
       {editorDialogs.loopEditor && (
         <LoopEditorDialog

--- a/modules/roland-sxx0-editor/src/pages/PatchesPage.tsx
+++ b/modules/roland-sxx0-editor/src/pages/PatchesPage.tsx
@@ -100,6 +100,10 @@ export function PatchesPage() {
     patches,
     setIndividualTones: () => {}, // Not needed for this page
     setIndividualPatches: () => {}, // Not needed for this page
+    // PatchesPage doesn't render the library tree, so the full
+    // refresh is a no-op here. The hook still calls it; the next
+    // LibraryPage visit re-scans on its own beforeEach effect.
+    handleRefreshLibrary: async () => {},
   });
 
   // Initialize client when adapter changes

--- a/modules/roland-sxx0-editor/src/plugins/s330-library-plugin.tsx
+++ b/modules/roland-sxx0-editor/src/plugins/s330-library-plugin.tsx
@@ -85,7 +85,9 @@ function S330MemoryPanelAdapter(props: DeviceMemoryRenderProps): JSX.Element {
  * CommonSamplePreviewPanel based on selection type.
  */
 function S330PreviewPanelAdapter({
-  selection,
+  // Tree-level selection is intentionally unused — see the
+  // pageSelection routing comment below.
+  selection: _selection,
   context,
 }: {
   selection: ItemSelection | null;
@@ -111,12 +113,21 @@ function S330PreviewPanelAdapter({
     );
   }
 
-  // No selection or no custom state - show empty state
-  if (!selection || !state) {
+  // The plugin-tree `selection` prop is only set by library-tree
+  // clicks (via `PluginLibraryBrowser.onSelectionChange`); clicks in
+  // `DeviceMemoryPanel` go through the page's `handleSelectDevice`
+  // which sets `state.pageSelection.source === 'device'` but leaves
+  // the tree-level `selection` null. Routing off `pageSelection`
+  // (page-level source of truth) rather than the tree-level `selection`
+  // prop covers both device-memory and library-tree clicks uniformly.
+  const pageSelection = state?.pageSelection;
+  if (!state || !pageSelection) {
+    // Use the canonical column-header chrome so the empty-state
+    // Preview title matches Device Memory / Library in typography.
     return (
       <div className="h-full flex flex-col">
-        <div className="p-3 border-b border-s330-accent">
-          <h3 className="font-bold text-s330-text">Preview</h3>
+        <div className="ac-panel-header">
+          <h3 className="ac-panel-header-title">Preview</h3>
         </div>
         <div className="flex-1 flex items-center justify-center p-4">
           <div className="text-center text-s330-muted text-sm">
@@ -126,8 +137,6 @@ function S330PreviewPanelAdapter({
       </div>
     );
   }
-
-  const pageSelection = state.pageSelection;
 
   // Route to appropriate preview panel based on selection type
   if (pageSelection?.type === 'sample' || pageSelection?.type === 'program') {
@@ -157,6 +166,10 @@ function S330PreviewPanelAdapter({
       onLoadSet={state.onLoadSet}
       onOpenInLoopEditor={state.onOpenInLoopEditor ? (name, _nodeType, path) => state.onOpenInLoopEditor!(name, path) : undefined}
       onOpenInSampleEditor={state.onOpenInSampleEditor ? (name, _nodeType, path) => state.onOpenInSampleEditor!(name, path) : undefined}
+      onExportDeviceTone={state.onExportDeviceTone}
+      onExportDevicePatch={state.onExportDevicePatch}
+      onEditDeviceTone={state.onEditDeviceTone}
+      onEditDevicePatch={state.onEditDevicePatch}
     />
   );
 }

--- a/modules/roland-sxx0-editor/src/plugins/s550-library-plugin.tsx
+++ b/modules/roland-sxx0-editor/src/plugins/s550-library-plugin.tsx
@@ -107,7 +107,9 @@ function S550MemoryPanelAdapter(props: DeviceMemoryRenderProps): JSX.Element {
  * CommonSamplePreviewPanel based on selection type.
  */
 function S550PreviewPanelAdapter({
-  selection,
+  // Tree-level selection is intentionally unused — see the
+  // pageSelection routing comment below.
+  selection: _selection,
   context,
 }: {
   selection: ItemSelection | null;
@@ -133,12 +135,21 @@ function S550PreviewPanelAdapter({
     );
   }
 
-  // No selection or no custom state - show empty state
-  if (!selection || !state) {
+  // The plugin-tree `selection` prop is only set by library-tree
+  // clicks (via `PluginLibraryBrowser.onSelectionChange`); clicks in
+  // `DeviceMemoryPanel` go through the page's `handleSelectDevice`
+  // which sets `state.pageSelection.source === 'device'` but leaves
+  // the tree-level `selection` null. Routing off `pageSelection`
+  // (page-level source of truth) rather than the tree-level `selection`
+  // prop covers both device-memory and library-tree clicks uniformly.
+  const pageSelection = state?.pageSelection;
+  if (!state || !pageSelection) {
+    // Use the canonical column-header chrome so the empty-state
+    // Preview title matches Device Memory / Library in typography.
     return (
       <div className="h-full flex flex-col">
-        <div className="p-3 border-b border-s330-accent">
-          <h3 className="font-bold text-s330-text">Preview</h3>
+        <div className="ac-panel-header">
+          <h3 className="ac-panel-header-title">Preview</h3>
         </div>
         <div className="flex-1 flex items-center justify-center p-4">
           <div className="text-center text-s330-muted text-sm">
@@ -148,8 +159,6 @@ function S550PreviewPanelAdapter({
       </div>
     );
   }
-
-  const pageSelection = state.pageSelection;
 
   // Route to appropriate preview panel based on selection type
   if (pageSelection?.type === 'sample' || pageSelection?.type === 'program') {
@@ -179,6 +188,10 @@ function S550PreviewPanelAdapter({
       onLoadSet={state.onLoadSet}
       onOpenInLoopEditor={state.onOpenInLoopEditor ? (name, _nodeType, path) => state.onOpenInLoopEditor!(name, path) : undefined}
       onOpenInSampleEditor={state.onOpenInSampleEditor ? (name, _nodeType, path) => state.onOpenInSampleEditor!(name, path) : undefined}
+      onExportDeviceTone={state.onExportDeviceTone}
+      onExportDevicePatch={state.onExportDevicePatch}
+      onEditDeviceTone={state.onEditDeviceTone}
+      onEditDevicePatch={state.onEditDevicePatch}
     />
   );
 }

--- a/modules/roland-sxx0-editor/src/plugins/shared/categories.tsx
+++ b/modules/roland-sxx0-editor/src/plugins/shared/categories.tsx
@@ -34,9 +34,15 @@ export function createTonesCategory(): CategoryPlugin {
     emptyMessage: 'No tones in library',
     dropMessage: 'Drop to save tone',
     acceptsExternalDrop: true,
+    // Shadow MIMEs published by DeviceMemoryPanel's tone dragstart
+    // (`application/x-s330-device-item/tone`) and by tree-internal
+    // library item drags of node type tone. Listed here so the
+    // PluginLibraryBrowser section dragover handler can discriminate
+    // tone-vs-patch drags during dragover without having to parse the
+    // dataTransfer JSON (which most browsers block during dragover).
     acceptedDropMimeTypes: [
-      'application/x-s330-device-drag',
-      'application/x-s330-library-drag',
+      'application/x-s330-device-item/tone',
+      'application/x-library-item/tone',
     ],
 
     canAcceptDrop: (dragData: unknown) => {
@@ -64,9 +70,12 @@ export function createPatchesCategory(): CategoryPlugin {
     emptyMessage: 'No patches in library',
     dropMessage: 'Drop to save patch',
     acceptsExternalDrop: true,
+    // Per-type shadow MIMEs (see tones category). Tones-only drags
+    // carry `*/tone` and patch-only drags carry `*/patch`; the
+    // section dragover handler picks the right section to highlight.
     acceptedDropMimeTypes: [
-      'application/x-s330-device-drag',
-      'application/x-s330-library-drag',
+      'application/x-s330-device-item/patch',
+      'application/x-library-item/patch',
     ],
 
     canAcceptDrop: (dragData: unknown) => {

--- a/modules/roland-sxx0-editor/src/plugins/shared/item-types.tsx
+++ b/modules/roland-sxx0-editor/src/plugins/shared/item-types.tsx
@@ -8,7 +8,17 @@
 
 import type { ItemTypePlugin } from '@audiocontrol/editor-core';
 import type { CommonSampleMeta, CommonProgramMeta } from '@audiocontrol/editor-core';
-import { WaveIcon, PatchIcon } from '@/components/library/LibraryTreeIcons';
+
+/**
+ * Single-letter mono lead-in tag used in place of a per-kind icon.
+ * Keeps the tree row vocabulary in the v3 typographic register
+ * (Departure Mono + accent muted) instead of fragmenting it into N
+ * distinct SVG glyphs. Folder rows still get the folder icon —
+ * folders are universal, items are typographic.
+ */
+function KindTag({ children }: { children: string }): JSX.Element {
+  return <span className="ac-tree-item-tag" aria-hidden="true">{children}</span>;
+}
 
 export type { CommonSampleMeta, CommonProgramMeta };
 
@@ -35,7 +45,7 @@ export const toneItemType: ItemTypePlugin<ToneMeta> = {
   typeId: 'tone',
   displayName: 'Tone',
 
-  renderIcon: () => <WaveIcon />,
+  renderIcon: () => <KindTag>T</KindTag>,
 
   renderTrailing: () => null,
 
@@ -94,7 +104,7 @@ export const patchItemType: ItemTypePlugin<PatchMeta> = {
   typeId: 'patch',
   displayName: 'Patch',
 
-  renderIcon: () => <PatchIcon />,
+  renderIcon: () => <KindTag>P</KindTag>,
 
   renderTrailing: (meta) => {
     if (!meta || meta.toneCount === undefined) return null;

--- a/modules/roland-sxx0-editor/src/plugins/shared/plugin-state-types.ts
+++ b/modules/roland-sxx0-editor/src/plugins/shared/plugin-state-types.ts
@@ -96,4 +96,14 @@ export interface PreviewPanelCustomState {
   onOpenInLoopEditor?: (name: string, path?: string[]) => void;
   onOpenInChopper?: (name: string, path?: string[]) => void;
   onOpenInSampleEditor?: (name: string, path?: string[]) => void;
+
+  // Device-memory action callbacks. Sibling actions to the library
+  // preview's IMPORT-TO-DEVICE / OPEN-IN-EDITOR row — they let the
+  // operator export a device-resident tone/patch to the library OR
+  // jump straight to the parameter editor for that slot, both
+  // triggered from the right-column preview pane.
+  onExportDeviceTone?: (toneIndex: number) => void;
+  onExportDevicePatch?: (patchIndex: number) => void;
+  onEditDeviceTone?: (toneIndex: number) => void;
+  onEditDevicePatch?: (patchIndex: number) => void;
 }

--- a/modules/roland-sxx0-editor/src/styles/_shared.css
+++ b/modules/roland-sxx0-editor/src/styles/_shared.css
@@ -559,10 +559,13 @@
   outline-offset: -2px;
 }
 
-/* Disclosure marker — matches `.ac-list-bank-chevron` (the
-   collapsible-group chevron used in PatchList / ToneList bank
-   headers) so the two affordances read as the same UI element.
-   Both: 1.1rem square inline-flex glyph in accent color. */
+/* Disclosure marker for native <details> on the home page's
+   learn-more sections. Visually mirrors the .ac-chevron primitive
+   but stays a separate name + rule because <details>/<summary> can't
+   straightforwardly mount a React component as its marker without
+   converting the disclosure to a controlled component. This is the
+   one accepted exception; do not pattern off it for editor surfaces —
+   editor surfaces render AcChevron. */
 .learn-more details > summary .marker {
   display: inline-flex;
   align-items: center;
@@ -867,6 +870,18 @@
   box-shadow: inset 0 0 0 2px var(--ac-color-accent);
 }
 
+/* Multi-select membership — a slot in the ctrl/shift-click multi-set
+   reads as "in the selection group" without overriding the page-level
+   anchor's stronger aria-selected highlight. Lighter accent tint +
+   dotted left-edge to differentiate from the solid-edge anchor. The
+   anchor itself ALSO joins the multi-set on the first ctrl-toggle, so
+   when both fire the anchor styling wins by selector specificity. */
+.ac-device-memory-row[data-multi-selected="true"] {
+  background: color-mix(in srgb, var(--ac-color-accent) 7%, transparent);
+  border-left-style: dotted;
+  border-left-color: color-mix(in srgb, var(--ac-color-accent) 70%, transparent);
+}
+
 .ac-device-memory-row--draggable {
   cursor: grab;
 }
@@ -977,21 +992,9 @@
   outline-offset: -2px;
 }
 
-/* Chevron glyph for the section eyebrow. Glyph swaps explicitly
-   (▾ ↔ ▸) rather than CSS-rotating a single glyph — the display
-   font (Departure Mono) doesn't carry a clean ▸ that survives a
-   rotation, and the swap matches the per-bank chevron in
-   `.ac-list-bank-chevron`. */
-.ac-device-memory-section-eyebrow-chevron {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 1rem;
-  height: 1rem;
-  font-size: 1rem;
-  line-height: 1;
-  color: var(--ac-color-accent);
-}
+/* (Section-eyebrow disclosure glyph is rendered via the AcChevron
+   component — no per-context class is declared. See
+   editor-core/src/design/chevron-primitives.css.) */
 
 /* ============================================================
    PREVIEW PANE — column-pane chrome used by the Library page's
@@ -1886,4 +1889,117 @@
 
 @media (prefers-reduced-motion: reduce) {
   .ac-detail-live-led { animation: none; }
+}
+
+/* =========================================================================
+   Export-dialog form chrome (v3 SlideDrawer body)
+   -------------------------------------------------------------------------
+   Module-scoped primitives for ExportToneDialog + ExportPatchDialog
+   bodies. The drawer chrome itself lives in editor-core's
+   overlay-primitives; these classes carry the form + detail-summary
+   composition inside it. Promote to editor-core once a second editor
+   adopts the same export-form pattern (per the Phase 9 promotion
+   gate documented in DESIGN-SYSTEM §"Phase 9 shared page primitives").
+   ========================================================================= */
+
+.ac-export-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-space-4);
+}
+
+.ac-export-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-space-2);
+}
+
+.ac-export-form-error {
+  margin: 0;
+  font-family: var(--ac-font-body);
+  font-size: var(--ac-text-sm);
+  color: var(--ac-color-danger);
+}
+
+/* Read-only detail summary rendered as a dl. Each row is a single
+   dt+dd pair, aligned with the eyebrow rhythm above. The list itself
+   sits inside a subdued panel to telegraph "this is context, not an
+   input" — matches the .ac-preview-pane convention. */
+.ac-export-summary {
+  margin: 0;
+  padding: var(--ac-space-3) var(--ac-space-4);
+  border: 1px solid color-mix(in srgb, var(--ac-color-accent) 22%, transparent);
+  border-radius: var(--ac-radius-sm, 4px);
+  background: color-mix(in srgb, var(--ac-color-surface-canvas) 60%, transparent);
+  display: grid;
+  gap: var(--ac-space-2);
+}
+
+.ac-export-summary-row {
+  display: grid;
+  grid-template-columns: minmax(7rem, max-content) 1fr;
+  align-items: baseline;
+  gap: var(--ac-space-3);
+  margin: 0;
+}
+
+.ac-export-summary-row > dt {
+  margin: 0;
+  font-family: var(--ac-font-display);
+  font-size: var(--ac-text-eyebrow);
+  letter-spacing: var(--ac-tracking-eyebrow);
+  text-transform: uppercase;
+  color: var(--ac-color-text-muted);
+}
+
+.ac-export-summary-row > dd {
+  margin: 0;
+  font-family: var(--ac-font-body);
+  font-size: var(--ac-text-sm);
+  color: var(--ac-color-text);
+}
+
+.ac-export-summary-row > dd.ac-capitalize {
+  text-transform: capitalize;
+}
+
+/* Batch-export item list — used by BatchExportDrawer to enumerate the
+   N items the operator is about to ship. Same subdued panel as
+   .ac-export-summary so the list reads as context (not editable). */
+.ac-batch-export-list {
+  margin: 0;
+  padding: var(--ac-space-3) var(--ac-space-4);
+  list-style: none;
+  border: 1px solid color-mix(in srgb, var(--ac-color-accent) 22%, transparent);
+  border-radius: var(--ac-radius-sm, 4px);
+  background: color-mix(in srgb, var(--ac-color-surface-canvas) 60%, transparent);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ac-space-1);
+  max-height: 22rem;
+  overflow-y: auto;
+}
+
+.ac-batch-export-row {
+  display: grid;
+  grid-template-columns: minmax(3.5rem, max-content) 1fr;
+  align-items: baseline;
+  gap: var(--ac-space-3);
+  padding: var(--ac-space-1) 0;
+}
+
+.ac-batch-export-slot {
+  font-family: var(--ac-font-mono);
+  font-size: var(--ac-text-sm);
+  color: var(--ac-color-accent);
+  font-variant-numeric: tabular-nums;
+}
+
+.ac-batch-export-name {
+  font-family: var(--ac-font-body);
+  font-size: var(--ac-text-sm);
+  color: var(--ac-color-text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }

--- a/modules/roland-sxx0-editor/test/e2e/device-library-roundtrip.spec.ts
+++ b/modules/roland-sxx0-editor/test/e2e/device-library-roundtrip.spec.ts
@@ -39,6 +39,12 @@ import {
   exportedToneHasWav,
   extractYamlFields,
 } from './helpers/roundtrip-helpers';
+// Playwright HTML5 DnD helper. Lives in the Wave-5 wiring helpers
+// alongside its sibling locators/seeders; the helper itself is
+// harness-agnostic (operates on any Locator + a shared DataTransfer)
+// so reusing it here keeps the DnD round-trip canonical instead of
+// re-implementing the same 5-event sequence per test category.
+import { simulateDragAndDrop } from '../wiring/library-flows-dnd-helpers';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -405,6 +411,154 @@ test.describe('Device Library Round Trip', () => {
         `Expected s330 sections in both original and exported YAML`
       );
     }
+  });
+
+  // -------------------------------------------------------------------------
+  // Tone Round Trip via Library Drag-Drop (BUG-001 regression coverage)
+  // -------------------------------------------------------------------------
+
+  test('tone round trip via library drag-drop: drag from device memory to library, confirm export, compare', async ({
+    page,
+  }) => {
+    // Mirrors the prior "tone round trip" but drives the export
+    // through the LibraryPage drag-drop path (DeviceMemoryPanel →
+    // library tones section) instead of the Tones-editor "Export"
+    // button. Both paths terminate in ExportToneDialog; this test
+    // is the regression gate for BUG-001 (empty catch in the dialog
+    // swallowed the synchronous precondition throw from
+    // `useLibraryExport`, so the confirm click was a silent no-op).
+    attachConsoleDebugListener(page);
+
+    // Steps 1-7: seed fixture, connect OPFS, import to slot 0 —
+    // identical to the prior test up through dismissing the import
+    // success dialog.
+    await writeToneFixtureToOPFS(
+      page, DEVICE_TYPE, TONE_FIXTURE_NAME, TONE_YAML, TONE_WAV_BASE64,
+    );
+    await connectToOPFS(page);
+
+    const toneItem = page.locator(
+      `[data-testid="library-tone-${TONE_FIXTURE_NAME}"]`,
+    );
+    await expect(toneItem).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await toneItem.click();
+
+    const importButton = page.locator('[data-testid="import-to-device-button"]');
+    await expect(importButton).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await importButton.click();
+
+    const slotSelect = page.locator('[data-testid="target-slot-select"]');
+    await expect(slotSelect).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await slotSelect.selectOption('0');
+
+    const confirmImport = page.locator('[data-testid="confirm-import-button"]');
+    await expect(confirmImport).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await confirmImport.click();
+
+    await waitForTransferWithHeartbeat(
+      page, 'import-success', 'import-progress', MIDI_TRANSFER_TIMEOUT_MS,
+    );
+
+    const importDone = page.locator('button', { hasText: 'Done' });
+    await importDone.click();
+
+    // Step 8: stay on LibraryPage. The successful import populated
+    // tones[0] in the device-data store, so device-tone-slot-0 in
+    // DeviceMemoryPanel becomes draggable (`draggable={!!tone}` per
+    // DeviceMemoryPanel.tsx:328).
+    const sourceSlot = page.locator('[data-testid="device-tone-slot-0"]');
+    await expect(sourceSlot).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await expect(sourceSlot).toHaveAttribute('draggable', 'true', {
+      timeout: UI_TIMEOUT_MS,
+    });
+
+    // Step 9: drag from the device tone slot to the library tones
+    // section. The shared `DataTransfer` round-trip exercises the real
+    // `DEVICE_DRAG_MIME` payload through
+    // `handleExternalDrop` → `useLibraryExport.handleDropDeviceTone`.
+    // Wave-5 wiring tests D-LIB-06/07 use the same locator + helper.
+    const dropTarget = page.locator(
+      '[data-category="tones"][data-testid="library-tones-section"]',
+    );
+    await expect(dropTarget).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await simulateDragAndDrop(page, sourceSlot, dropTarget);
+
+    // Step 10: ExportToneDialog opens. v3 chrome is a right-edge
+    // SlideDrawer that renders `role="dialog"` with the title
+    // "Export tone to library" as its accessible name (h2 inside
+    // .ac-drawer-header). Targeting via role + name keeps the
+    // selector semantic and survives any future testid drift.
+    const exportDialog = page.getByRole('dialog', {
+      name: /Export tone to library/i,
+    });
+    await expect(exportDialog).toBeVisible({ timeout: UI_TIMEOUT_MS });
+
+    // Step 11: click Export. Pre-BUG-001-fix this click was silent —
+    // the synchronous precondition throw was swallowed by the
+    // dialog's empty catch and never surfaced as `localError` or
+    // `operationError`. The v3 rewrite captures both throw paths and
+    // any rejected `onExport` promise into the step log's failed row.
+    const confirmExport = exportDialog.locator('[data-testid="export-confirm"]');
+    await expect(confirmExport).toBeVisible({ timeout: UI_TIMEOUT_MS });
+    await expect(confirmExport).toBeEnabled({ timeout: UI_TIMEOUT_MS });
+    await confirmExport.click();
+
+    // Step 12: poll the dialog for the success line so each iter is a
+    // heartbeat-feeding assertion (matches the existing pattern).
+    // The v3 success copy lives in `.ac-step-summary` inside the
+    // step-log body — same substring match as before.
+    const exportSuccess = exportDialog.locator('text=exported successfully');
+    {
+      const deadline = Date.now() + EXPORT_TIMEOUT_MS;
+      while (Date.now() < deadline) {
+        if (await exportSuccess.isVisible()) break;
+        await expect(exportDialog).toBeVisible({ timeout: 3_000 });
+        await page.waitForTimeout(500);
+      }
+      await expect(exportSuccess).toBeVisible({ timeout: 3_000 });
+    }
+
+    // The v3 footer reuses the `export-cancel` testid for the
+    // terminal Done button (single footer slot across lifecycle
+    // states) — keeps the locator surface lean.
+    const exportDone = exportDialog.locator('[data-testid="export-cancel"]');
+    await expect(exportDone).toHaveText(/Done/);
+    await exportDone.click();
+
+    // Step 13: verify an exported tone landed in OPFS with the
+    // contracted shape. The exhaustive field-for-field comparison
+    // lives in the prior round-trip test; here we only need to prove
+    // drag-drop → confirm produced a new tone with the right
+    // format/device/version + a sibling WAV.
+    const exportedTones = await listExportedTones(page, DEVICE_TYPE);
+    const exportedNames = exportedTones.filter(
+      (name) => name !== TONE_FIXTURE_NAME,
+    );
+    expect(
+      exportedNames.length,
+      `Expected at least one newly exported tone via drag-drop path. ` +
+        `OPFS tone names: [${exportedTones.join(', ')}]`,
+    ).toBeGreaterThanOrEqual(1);
+
+    const exportedName = exportedNames[0];
+    const hasWav = await exportedToneHasWav(page, DEVICE_TYPE, exportedName);
+    expect(
+      hasWav,
+      `Expected WAV file alongside exported tone "${exportedName}"`,
+    ).toBe(true);
+
+    const exportedYaml = await readExportedToneYaml(
+      page, DEVICE_TYPE, exportedName,
+    );
+    const exportedFields = extractYamlFields(exportedYaml);
+    expect(exportedFields['format']).toBe('sampler-tone');
+    // S-series library contract: every S-330 / S-550 tone uses
+    // `device: s330` as the shared key, regardless of which device
+    // produced the export (matches TONE_YAML's frontmatter at the
+    // top of this file). Comparing against `DEVICE_TYPE` would
+    // incorrectly expect `s550` when E2E_DEVICE_TYPE=s550.
+    expect(exportedFields['device']).toBe('s330');
+    expect(exportedFields['version']).toBe('1');
   });
 
   // -------------------------------------------------------------------------

--- a/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
+++ b/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
@@ -635,6 +635,63 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
     await expect(page.getByTestId('export-confirm')).toBeVisible();
   });
 
+  test('D-LIB-30: device-memory multi-select with Cmd-click skips intermediate slots (non-contiguous selection)', async ({ page }) => {
+    // The dispatcher branches on `e.ctrlKey || e.metaKey` and seeds the
+    // prior anchor on the first modifier-click; the cascading prior-
+    // session "only shift works" observation came from operators who
+    // assumed ctrl/cmd would extend contiguously like shift. This spec
+    // exercises the genuinely non-contiguous case: anchor on slot 0
+    // then meta-click slot 2 and slot 4 — intermediate slots 1 and 3
+    // are seeded with tones but MUST NOT enter the multi-set. The drag
+    // payload's `indices` array therefore carries exactly 3 entries
+    // and the drawer mounts with 3 items.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    await connectLibraryOPFS(page);
+    await seedDeviceTone(page, { slot: 0, name: 'TestToneA' });
+    await seedDeviceTone(page, { slot: 1, name: 'TestToneB' });
+    await seedDeviceTone(page, { slot: 2, name: 'TestToneC' });
+    await seedDeviceTone(page, { slot: 3, name: 'TestToneD' });
+    await seedDeviceTone(page, { slot: 4, name: 'TestToneE' });
+
+    const slot0 = deviceToneSlot(page, 'T11');
+    const slot1 = deviceToneSlot(page, 'T12');
+    const slot2 = deviceToneSlot(page, 'T13');
+    const slot3 = deviceToneSlot(page, 'T14');
+    const slot4 = deviceToneSlot(page, 'T15');
+    for (const s of [slot0, slot1, slot2, slot3, slot4]) {
+      await expect(s).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    }
+
+    await slot0.click();
+    await slot2.click({ modifiers: ['ControlOrMeta'] });
+    await slot4.click({ modifiers: ['ControlOrMeta'] });
+
+    // Selected: 0, 2, 4. Unselected: 1, 3.
+    await expect(slot0).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    await expect(slot2).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    await expect(slot4).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    // Intermediate slots remain unselected — the attribute should not
+    // be present (Playwright treats missing attributes as null).
+    await expect(slot1).not.toHaveAttribute('data-multi-selected', 'true');
+    await expect(slot3).not.toHaveAttribute('data-multi-selected', 'true');
+
+    const target = page.locator('[data-category="tones"][data-testid="library-tones-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await simulateDragAndDrop(page, slot0, target);
+
+    // Drawer mounts with exactly 3 items — the indices array carried
+    // [0, 2, 4], so item-0/2/4 testids appear and item-1/3 do not.
+    await expect(
+      page.getByRole('heading', { name: /Export 3 tones to library/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('batch-export-item-0')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-2')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-4')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-1')).toHaveCount(0);
+    await expect(page.getByTestId('batch-export-item-3')).toHaveCount(0);
+  });
+
   test('D-LIB-29: device-memory multi-select on patches + drag of any member opens the BatchExportDrawer with kind="patch"', async ({ page }) => {
     // Symmetric to D-LIB-28 but exercises the patch side of the
     // dispatcher (handlePatchClick) and the patch branch of

--- a/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
+++ b/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
@@ -92,9 +92,14 @@ import {
 
 test.describe('Capabilities — Library DnD (Wave 5)', () => {
   let pageErrors: string[];
+  /** Tests that INTENTIONALLY trigger console.error (e.g. D-LIB-31's
+   *  continue-on-error verification) can push regexes here. afterEach
+   *  drops matching entries before asserting. Cleared each test. */
+  let expectedErrorPatterns: RegExp[];
 
   test.beforeEach(async ({ page }) => {
     pageErrors = [];
+    expectedErrorPatterns = [];
     page.on('pageerror', (err) => {
       pageErrors.push(err.message);
     });
@@ -109,8 +114,11 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
   });
 
   test.afterEach(() => {
+    const unexpected = pageErrors.filter(
+      (msg) => !expectedErrorPatterns.some((pat) => pat.test(msg)),
+    );
     expect(
-      pageErrors,
+      unexpected,
       'no page errors during library DnD interactions',
     ).toEqual([]);
   });
@@ -690,6 +698,104 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
     await expect(page.getByTestId('batch-export-item-4')).toBeVisible();
     await expect(page.getByTestId('batch-export-item-1')).toHaveCount(0);
     await expect(page.getByTestId('batch-export-item-3')).toHaveCount(0);
+  });
+
+  test('D-LIB-31: batch export continues past per-item failure — every item gets its own failed row instead of aborting at the first error', async ({ page }) => {
+    // The continue-on-error contract: a per-item failure inside the
+    // batch loop (e.g. `client.requestWaveData` throws for one slot)
+    // records the error in `batchExportFailures` and the loop moves
+    // on to the next item. The drawer's step log surfaces ✗ on each
+    // failed row instead of aborting at the first error — that abort
+    // was the original bug (user screenshot: T15 succeeded, T16 failed
+    // with "Wave data request rejected", T17 never started).
+    //
+    // The cleanest reproduction in the test environment is to fail
+    // EVERY item with a distinct error message and assert all three
+    // failure rows render. Pre-fix this would have aborted at item 1
+    // and step rows 2 + 3 would never have surfaced; post-fix all
+    // three appear with their respective messages. The partial-
+    // success summary message ("X of N exported · Y failed") is
+    // covered separately by the dispatcher unit logic, not asserted
+    // here — faking exportToneToDirectory's success path requires
+    // valid 12-bit packed wave data + tone-converter-compatible YAML
+    // structure that the wiring harness deliberately doesn't ship.
+    //
+    // Reproducing the per-slot failure requires forcing
+    // `requestWaveData` to throw with a known message. The dev-mode
+    // test seam `window.__samplerClient` (LibraryPage.tsx) exposes
+    // the in-use client so the test can monkeypatch its method.
+    // Mirrors the existing `__deviceDataStore` seam used by
+    // `seedDeviceTone`.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    await connectLibraryOPFS(page);
+    await seedDeviceTone(page, { slot: 0, name: 'TestKick1' });
+    await seedDeviceTone(page, { slot: 1, name: 'TestKick2' });
+    await seedDeviceTone(page, { slot: 2, name: 'TestKick3' });
+
+    // The per-item failures we're about to trigger are console.errored
+    // by handleBatchExport (intentionally — operators want the cause
+    // logged beyond the in-drawer step log). Whitelist that pattern so
+    // the suite-wide "no console errors" assertion doesn't fire on the
+    // contract under test.
+    expectedErrorPatterns.push(/\[useLibraryExport\] Batch item T1\d \(tone\) failed/);
+
+    // Pre-fix behavior: loop throws at slot 0 and slots 1 + 2 never
+    // run. Post-fix: each per-slot throw is caught + recorded; the
+    // distinct error messages prove the loop reached each item.
+    await page.evaluate(() => {
+      const w = window as unknown as { __samplerClient?: { requestWaveData: (i: number, cb?: (r: number, t: number) => void) => Promise<unknown> } };
+      const client = w.__samplerClient;
+      if (!client) throw new Error('__samplerClient seam not present — LibraryPage.tsx dev-mode export missing');
+      client.requestWaveData = async (toneIndex: number) => {
+        throw new Error(`SimulatedRejection_slot_${toneIndex}`);
+      };
+    });
+
+    const slot0 = deviceToneSlot(page, 'T11');
+    const slot1 = deviceToneSlot(page, 'T12');
+    const slot2 = deviceToneSlot(page, 'T13');
+    for (const s of [slot0, slot1, slot2]) {
+      await expect(s).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    }
+
+    await slot0.click();
+    await slot1.click({ modifiers: ['ControlOrMeta'] });
+    await slot2.click({ modifiers: ['ControlOrMeta'] });
+
+    const target = page.locator('[data-category="tones"][data-testid="library-tones-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await simulateDragAndDrop(page, slot0, target);
+
+    await expect(
+      page.getByRole('heading', { name: /Export 3 tones to library/i }),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Kick off the batch.
+    await page.getByTestId('export-confirm').click();
+
+    // Wait for the all-failed terminal state. The step-log final row
+    // emits this label only when every per-item try/catch fired.
+    await expect(
+      page.getByText(/Batch failed — all 3 items errored/i),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Three per-item failure rows plus a final summary row (also
+    // styled failed because the all-failed terminal state sets
+    // batchExportError, which useStepHistory marks the final summary
+    // row as failed too). Pre-fix the loop would have aborted at slot
+    // 0 — only ONE failed row would exist. The load-bearing assertion
+    // is the >=3 per-item rows; counting summary + per-item gives 4.
+    const failedStepRows = page.locator('.ac-step-row--failed');
+    await expect(failedStepRows).toHaveCount(4);
+
+    // Each row carries its own distinct error message — proves each
+    // item ran. If the loop had aborted at slot 0, rows 2 + 3 would
+    // never have been populated.
+    await expect(page.getByText('SimulatedRejection_slot_0')).toBeVisible();
+    await expect(page.getByText('SimulatedRejection_slot_1')).toBeVisible();
+    await expect(page.getByText('SimulatedRejection_slot_2')).toBeVisible();
+
   });
 
   test('D-LIB-29: device-memory multi-select on patches + drag of any member opens the BatchExportDrawer with kind="patch"', async ({ page }) => {

--- a/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
+++ b/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
@@ -798,6 +798,95 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
 
   });
 
+  test('D-LIB-32: ctrl-click does not move the anchor, so a subsequent shift-click ranges from the original plain-click anchor', async ({ page }) => {
+    // Regression coverage for AUDIT-20260521-01. The dispatcher used
+    // to overwrite `lastToneAnchorRef.current` inside the ctrl/meta
+    // branch, so a subsequent shift-click would range from the most-
+    // recently ctrl-clicked slot instead of the original plain-click
+    // anchor. Matches the OS-standard file-manager idiom (the anchor
+    // moves on plain click or shift click; ctrl/meta toggles
+    // membership without moving the anchor).
+    //
+    // Sequence:
+    //   1. Plain-click T11 — anchor = T11.
+    //   2. Cmd/Ctrl-click T13 — multi-set = {T11, T13}; anchor STAYS T11.
+    //   3. Shift-click T15 — range from T11 → {T11, T12, T13, T14, T15}.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    await connectLibraryOPFS(page);
+    await seedDeviceTone(page, { slot: 0, name: 'TestToneA' });
+    await seedDeviceTone(page, { slot: 1, name: 'TestToneB' });
+    await seedDeviceTone(page, { slot: 2, name: 'TestToneC' });
+    await seedDeviceTone(page, { slot: 3, name: 'TestToneD' });
+    await seedDeviceTone(page, { slot: 4, name: 'TestToneE' });
+
+    const slot0 = deviceToneSlot(page, 'T11');
+    const slot1 = deviceToneSlot(page, 'T12');
+    const slot2 = deviceToneSlot(page, 'T13');
+    const slot3 = deviceToneSlot(page, 'T14');
+    const slot4 = deviceToneSlot(page, 'T15');
+    for (const s of [slot0, slot1, slot2, slot3, slot4]) {
+      await expect(s).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    }
+
+    // Step 1: plain click sets anchor + clears multi-set.
+    await slot0.click();
+    // Step 2: ctrl-click adds T13 — anchor stays at T11.
+    await slot2.click({ modifiers: ['ControlOrMeta'] });
+    // Step 3: shift-click T15 — range from anchor T11 (NOT T13).
+    await slot4.click({ modifiers: ['Shift'] });
+
+    // Post-condition: T11-T15 all selected (range from anchor).
+    for (const s of [slot0, slot1, slot2, slot3, slot4]) {
+      await expect(s).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    }
+
+    // The drag payload should carry all 5 indices.
+    const target = page.locator('[data-category="tones"][data-testid="library-tones-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await simulateDragAndDrop(page, slot0, target);
+
+    await expect(
+      page.getByRole('heading', { name: /Export 5 tones to library/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('batch-export-item-0')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-1')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-2')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-3')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-4')).toBeVisible();
+  });
+
+  test('D-LIB-33: export drawer eyebrow reflects the active device name (S-550), not a hardcoded S-330 label', async ({ page }) => {
+    // Regression coverage for AUDIT-20260521-02. All three export
+    // drawers used to hardcode "S330" in the eyebrow row instead of
+    // deriving from useDeviceConfig(). The bug only surfaced on the
+    // s550 surface because every prior wiring test ran via LIBRARY_URL
+    // (the s330 URL). This spec exercises the s550 mount + asserts
+    // the eyebrow reads "S-550".
+    //
+    // Single-item ExportToneDialog is the canonical surface; the
+    // patch + batch drawers share the same shape (verified by
+    // tone/patch/batch all using deviceName from useDeviceConfig).
+    const S550_LIBRARY_URL =
+      '/roland/s550/editor/library?midi=simulated&scenario=load-everything';
+    await page.goto(S550_LIBRARY_URL);
+    await cleanupOPFS(page);
+    await connectLibraryOPFS(page);
+    await seedDeviceTone(page, { slot: 0, name: 'TestTone1' });
+
+    const source = deviceToneSlot(page, 'T11');
+    await expect(source).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+
+    const target = page.locator('[data-category="tones"][data-testid="library-tones-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await simulateDragAndDrop(page, source, target);
+
+    await expect(
+      page.getByRole('heading', { name: /Export tone to library/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('export-tone-device-name')).toHaveText('S-550');
+  });
+
   test('D-LIB-29: device-memory multi-select on patches + drag of any member opens the BatchExportDrawer with kind="patch"', async ({ page }) => {
     // Symmetric to D-LIB-28 but exercises the patch side of the
     // dispatcher (handlePatchClick) and the patch branch of

--- a/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
+++ b/modules/roland-sxx0-editor/test/wiring/library-flows-dnd.spec.ts
@@ -246,11 +246,14 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
 
     await simulateDragAndDrop(page, source, target);
 
+    // v3 SlideDrawer title is sentence-case per the design language
+    // (matches sibling drawers like MoveDialog "Move \"<name>\"").
     await expect(
-      page.getByRole('heading', { name: 'Export Tone to Library' }),
+      page.getByRole('heading', { name: /Export tone to library/i }),
     ).toBeVisible({ timeout: 5_000 });
-    // Dialog's content-defining affordances: confirm + cancel buttons
-    // (`ExportToneDialog.tsx:165-175`).
+    // Dialog's content-defining affordances: Export (confirm) + Cancel
+    // buttons in the SlideDrawer footer (same data-testids preserved
+    // across the v3 chrome migration).
     await expect(page.getByTestId('export-confirm')).toBeVisible();
     await expect(page.getByTestId('export-cancel')).toBeVisible();
   });
@@ -274,8 +277,9 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
 
     await simulateDragAndDrop(page, source, target);
 
+    // v3 SlideDrawer title — see D-LIB-06 above for the casing note.
     await expect(
-      page.getByRole('heading', { name: 'Export Patch to Library' }),
+      page.getByRole('heading', { name: /Export patch to library/i }),
     ).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId('export-confirm')).toBeVisible();
     await expect(page.getByTestId('export-cancel')).toBeVisible();
@@ -347,5 +351,369 @@ test.describe('Capabilities — Library DnD (Wave 5)', () => {
     // "Wave Memory:" used as the allocation-preview label
     // (`ImportSamplesDialog.tsx:484`).
     await expect(page.getByText('Wave Memory', { exact: true })).toBeVisible();
+  });
+
+  // -----------------------------------------------------------------
+  // D-LIB-24 / D-LIB-25: In-library moves (single + batch)
+  // -----------------------------------------------------------------
+  //
+  // Coverage gap discovered 2026-05-21: drag-to-folder, the most basic
+  // library operation, had NO test before. The bug it would have caught:
+  // `useLibraryOperations.onMove` skipped the strategy hook entirely,
+  // routing every move through the common-area `moveItem` (which only
+  // resolves under `library/common/samples/`). Roland's tones/patches
+  // live under `library/s330/…`, so every in-library drag failed with
+  // "file or directory could not be found." Fixed by adding
+  // `LibraryOperationsStrategy.moveItem` + routing onMove/onBatchMove
+  // through it; these specs are the regression gate.
+  //
+  // Both specs assert directly on OPFS state after the drag so a future
+  // adapter-typing or path-prefix regression fails loudly here instead
+  // of in the operator's browser.
+
+  /**
+   * Resolve a tree-row DOM node by its data-testid, then return the
+   * outer `[role="treeitem"]` ancestor — the actual DnD-bearing element
+   * the production `onDrop` handler is wired to.
+   */
+  async function treeRowFor(page: Page, testId: string) {
+    return page.evaluateHandle((id) => {
+      const inner = document.querySelector(`[data-testid="${id}"]`);
+      return inner?.closest('[role="treeitem"]') ?? null;
+    }, testId);
+  }
+
+  /**
+   * Resolve a folder tree row by its visible text. Folders don't carry
+   * a stable per-folder data-testid — operator-typed folder names route
+   * to the same `library-folder-<id>` shape that the editor doesn't
+   * promise to keep stable across schema rounds. The text lookup is the
+   * cheap, robust path for the regression spec.
+   */
+  async function folderRowByText(page: Page, name: string) {
+    return page.evaluateHandle((n) => {
+      const span = Array.from(document.querySelectorAll('span.ac-tree-node-name'))
+        .find((e) => e.textContent === n);
+      return span?.closest('[role="treeitem"]') ?? null;
+    }, name);
+  }
+
+  /**
+   * Seed an empty subfolder under `library/s330/<category>/`. The
+   * patches/tones helpers don't have a "create folder" companion, and
+   * driving the production createFolder dialog from a test would be
+   * a second test in disguise; writing directly to OPFS keeps this
+   * spec focused on the move chain.
+   */
+  async function seedSubfolder(
+    page: Page,
+    category: 'patches' | 'tones',
+    folderName: string,
+  ): Promise<void> {
+    await page.evaluate(
+      async ({ category, folderName }) => {
+        const root = await navigator.storage.getDirectory();
+        const lib = await root.getDirectoryHandle('library', { create: true });
+        const s330 = await lib.getDirectoryHandle('s330', { create: true });
+        const cat = await s330.getDirectoryHandle(category, { create: true });
+        await cat.getDirectoryHandle(folderName, { create: true });
+      },
+      { category, folderName },
+    );
+  }
+
+  /** Assert an item directory exists at the given OPFS path. */
+  async function assertOpfsHasPatch(
+    page: Page,
+    parentPath: string[],
+    name: string,
+  ): Promise<boolean> {
+    return page.evaluate(
+      async ({ parentPath, name }) => {
+        const root = await navigator.storage.getDirectory();
+        let cur: FileSystemDirectoryHandle = root;
+        for (const seg of parentPath) {
+          cur = await cur.getDirectoryHandle(seg);
+        }
+        try {
+          await cur.getDirectoryHandle(name);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { parentPath, name },
+    );
+  }
+
+  test('D-LIB-24: dragging a single library patch onto a folder row moves it under that folder', async ({ page }) => {
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    const { patchDirName } = await seedOPFSPatch(page, { targetName: 'hhc-test' });
+    await seedSubfolder(page, 'patches', 'DRUMS');
+    await connectLibraryOPFS(page);
+
+    const source = page.getByTestId(`library-patch-${patchDirName}`);
+    await expect(source).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('span.ac-tree-node-name', { hasText: 'DRUMS' })).toBeVisible({ timeout: 5_000 });
+
+    const sourceRow = await treeRowFor(page, `library-patch-${patchDirName}`);
+    const drumsRow = await folderRowByText(page, 'DRUMS');
+    await simulateDragAndDrop(page, sourceRow as never, drumsRow as never);
+
+    // Wait for the post-move refresh to land + assert OPFS state.
+    await expect
+      .poll(
+        () => assertOpfsHasPatch(page, ['library', 's330', 'patches', 'DRUMS'], patchDirName),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+    expect(await assertOpfsHasPatch(page, ['library', 's330', 'patches'], patchDirName)).toBe(false);
+  });
+
+  test('D-LIB-27: Ctrl-click multi-select keeps the original anchor row highlighted alongside the new toggles', async ({ page }) => {
+    // Before the seed fix, `handleMultiSelect`'s toggle branch
+    // initialised `next = new Set(multiSelectedIds)` (size 0 after a
+    // plain click) and added ONLY the Ctrl-clicked id. The page-level
+    // anchor stayed in `selection.node.id`, but TreeView's
+    // `isSelected` check (`selectedIds ? selectedIds.has(id) : selectedId === id`)
+    // ignores `selectedId` the moment `selectedIds` is non-undefined,
+    // so the anchor row visually dropped its highlight — operator
+    // saw their initial click disappear the second they Ctrl-clicked
+    // a sibling. Fix: seed `lastSelectedIdRef.current` into the
+    // toggle set when starting from empty.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    const hhc = await seedOPFSPatch(page, { targetName: 'hhc-test' });
+    const hho = await seedOPFSPatch(page, { targetName: 'hho-test' });
+    const snare = await seedOPFSPatch(page, { targetName: 'snare-test' });
+    await connectLibraryOPFS(page);
+
+    for (const dir of [hhc.patchDirName, hho.patchDirName, snare.patchDirName]) {
+      await expect(page.getByTestId(`library-patch-${dir}`)).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Plain click on HHC (page-level anchor).
+    await page.getByTestId(`library-patch-${hhc.patchDirName}`).click();
+    await expect(page.getByTestId(`library-patch-${hhc.patchDirName}`))
+      .toHaveClass(/ac-tree-node--selected/);
+
+    // Ctrl-click on HHO and SNARE.
+    await page.getByTestId(`library-patch-${hho.patchDirName}`).click({ modifiers: ['ControlOrMeta'] });
+    await page.getByTestId(`library-patch-${snare.patchDirName}`).click({ modifiers: ['ControlOrMeta'] });
+
+    // All three rows must carry the selected class — the anchor row
+    // is the regression gate. If the anchor seed regresses, HHC drops
+    // .ac-tree-node--selected and this assertion fails first.
+    await expect(page.getByTestId(`library-patch-${hhc.patchDirName}`))
+      .toHaveClass(/ac-tree-node--selected/);
+    await expect(page.getByTestId(`library-patch-${hho.patchDirName}`))
+      .toHaveClass(/ac-tree-node--selected/);
+    await expect(page.getByTestId(`library-patch-${snare.patchDirName}`))
+      .toHaveClass(/ac-tree-node--selected/);
+  });
+
+  test('D-LIB-26: moving the currently-selected patch out of a folder clears the stale selection (no FAILED TO LOAD preview)', async ({ page }) => {
+    // Reverse-direction move regression. The operator selects HHC
+    // inside DRUMS, then drags it back to the patches root. The move
+    // succeeds OPFS-wise (D-LIB-24's path covers that), but the
+    // page-level selection still holds `path: ['DRUMS']`. The preview
+    // pane's `useEffect([selection, libraryHandle])` then tries to
+    // load `library/s330/patches/DRUMS/HHC/patch.yaml`, which no
+    // longer exists, and renders "FAILED TO LOAD" — making it look
+    // like the move destroyed data even though the patch landed at
+    // `library/s330/patches/HHC/` correctly. The Roland strategy's
+    // `moveItem` clears the selection on a path-matching move so the
+    // preview drops back to the empty state instead of a stale error.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    // Seed the patch INSIDE a DRUMS subfolder so the source path is
+    // `['DRUMS']` rather than the empty root.
+    await page.evaluate(async () => {
+      const root = await navigator.storage.getDirectory();
+      const lib = await root.getDirectoryHandle('library', { create: true });
+      const s330 = await lib.getDirectoryHandle('s330', { create: true });
+      const patches = await s330.getDirectoryHandle('patches', { create: true });
+      const drums = await patches.getDirectoryHandle('DRUMS', { create: true });
+      const d = await drums.getDirectoryHandle('hhc-test', { create: true });
+      const y = await d.getFileHandle('patch.yaml', { create: true });
+      const w = await y.createWritable();
+      await w.write(
+        'format: sampler-patch\ndevice: s330\nversion: 1\nname: "Basic Patch"\nlevel: 100\ns330:\n  keyMode: normal\n  benderRange: 2\n',
+      );
+      await w.close();
+    });
+    await connectLibraryOPFS(page);
+
+    // Expand DRUMS so the patch row is in the DOM.
+    const drumsRow = page.locator('span.ac-tree-node-name', { hasText: 'DRUMS' }).locator('xpath=ancestor::*[@role="treeitem"][1]');
+    await expect(drumsRow).toBeVisible({ timeout: 5_000 });
+    await drumsRow.click();
+    await expect(page.getByTestId('library-patch-drums-hhc-test')).toBeVisible({ timeout: 5_000 });
+
+    // Select the patch (single-click without modifier — populates page
+    // selection so the preview pane mounts the patch body).
+    await page.getByTestId('library-patch-drums-hhc-test').click();
+    await expect(page.locator('[data-testid="library-preview-panel"]'))
+      .toContainText('Basic Patch', { timeout: 5_000 });
+
+    // Drag the selected patch to the patches root.
+    const sourceRow = await treeRowFor(page, 'library-patch-drums-hhc-test');
+    const target = page.locator('[data-category="patches"][data-testid="library-patches-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+    await simulateDragAndDrop(page, sourceRow as never, target);
+
+    // Post-move assertions:
+    // 1) OPFS state moved correctly.
+    await expect
+      .poll(
+        () => assertOpfsHasPatch(page, ['library', 's330', 'patches'], 'hhc-test'),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+    expect(await assertOpfsHasPatch(page, ['library', 's330', 'patches', 'DRUMS'], 'hhc-test')).toBe(false);
+
+    // 2) Preview pane does NOT show the stale error. The empty state
+    //    "Select an item to view details" is the post-clear render.
+    await expect(page.locator('[data-testid="library-preview-panel"]'))
+      .not.toContainText('FAILED TO LOAD', { ignoreCase: true });
+  });
+
+  test('D-LIB-28: device-memory multi-select + drag of any member opens the BatchExportDrawer with every selected slot', async ({ page }) => {
+    // The device-memory multi-select dispatcher lives in
+    // DeviceMemoryPanel.handleToneClick: plain click sets the anchor,
+    // ctrl/meta-click toggles membership (seeding the prior anchor on
+    // the first toggle). When a member is dragged with size > 1, the
+    // dragstart payload includes `indices` — and
+    // useLibraryExport.handleDropDeviceTone opens BatchExportDrawer
+    // instead of the single-item dialog.
+    //
+    // The single-item D-LIB-06 already covers the size=1 path. This
+    // spec specifically asserts the size>1 path: three slots ctrl-
+    // selected, drag any one, drawer mounts with all three.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    await connectLibraryOPFS(page);
+    await seedDeviceTone(page, { slot: 0, name: 'TestToneA' });
+    await seedDeviceTone(page, { slot: 1, name: 'TestToneB' });
+    await seedDeviceTone(page, { slot: 2, name: 'TestToneC' });
+
+    const slotA = deviceToneSlot(page, 'T11');
+    const slotB = deviceToneSlot(page, 'T12');
+    const slotC = deviceToneSlot(page, 'T13');
+    await expect(slotA).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    await expect(slotB).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    await expect(slotC).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+
+    // Plain click on T11 sets the anchor (selected, single-select); the
+    // multi-set is cleared. Ctrl-clicks on T12 then T13 add to the set,
+    // and on the first ctrl-click the prior anchor (T11) is seeded into
+    // the set so it stays highlighted alongside the new toggles.
+    await slotA.click();
+    await slotB.click({ modifiers: ['ControlOrMeta'] });
+    await slotC.click({ modifiers: ['ControlOrMeta'] });
+
+    await expect(slotA).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    await expect(slotB).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    await expect(slotC).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+
+    const target = page.locator('[data-category="tones"][data-testid="library-tones-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+
+    await simulateDragAndDrop(page, slotA, target);
+
+    // Drawer title carries the item count; per-item rows surface in
+    // the eyebrow + the item list. The drawer reuses the same
+    // SlideDrawer chrome as the single-item flows so the heading-by-
+    // name lookup is consistent with D-LIB-06.
+    await expect(
+      page.getByRole('heading', { name: /Export 3 tones to library/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('batch-export-item-0')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-1')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-2')).toBeVisible();
+    await expect(page.getByTestId('export-confirm')).toBeVisible();
+  });
+
+  test('D-LIB-29: device-memory multi-select on patches + drag of any member opens the BatchExportDrawer with kind="patch"', async ({ page }) => {
+    // Symmetric to D-LIB-28 but exercises the patch side of the
+    // dispatcher (handlePatchClick) and the patch branch of
+    // useLibraryExport.handleDropDevicePatch. The code shape mirrors
+    // tone batch one-to-one; this spec just keeps the patch path from
+    // silently regressing when someone touches one and forgets the
+    // sibling.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    await connectLibraryOPFS(page);
+    await seedDevicePatch(page, { slot: 0, name: 'TestPatchA' });
+    await seedDevicePatch(page, { slot: 1, name: 'TestPatchB' });
+    await seedDevicePatch(page, { slot: 2, name: 'TestPatchC' });
+
+    const slotA = devicePatchSlot(page, 'P11');
+    const slotB = devicePatchSlot(page, 'P12');
+    const slotC = devicePatchSlot(page, 'P13');
+    await expect(slotA).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    await expect(slotB).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+    await expect(slotC).toHaveAttribute('draggable', 'true', { timeout: 5_000 });
+
+    await slotA.click();
+    await slotB.click({ modifiers: ['ControlOrMeta'] });
+    await slotC.click({ modifiers: ['ControlOrMeta'] });
+
+    await expect(slotA).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    await expect(slotB).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+    await expect(slotC).toHaveAttribute('data-multi-selected', 'true', { timeout: 2_000 });
+
+    const target = page.locator('[data-category="patches"][data-testid="library-patches-section"]');
+    await expect(target).toBeVisible({ timeout: 5_000 });
+
+    await simulateDragAndDrop(page, slotA, target);
+
+    await expect(
+      page.getByRole('heading', { name: /Export 3 patches to library/i }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('batch-export-item-0')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-1')).toBeVisible();
+    await expect(page.getByTestId('batch-export-item-2')).toBeVisible();
+    await expect(page.getByTestId('export-confirm')).toBeVisible();
+  });
+
+  test('D-LIB-25: batch drag of 3 multi-selected patches to a folder moves every selected item', async ({ page }) => {
+    // Multi-select gesture in PluginLibraryBrowser: ctrlKey/metaKey click
+    // on each row adds it to `multiSelectedIds`. When the drag fires
+    // with size > 1 and the dragged node is in the set, the production
+    // path calls `onBatchMove` rather than `onMove` — the bug fixed
+    // alongside D-LIB-24 also missed this branch, so the batch path
+    // gets its own regression assertion.
+    await page.goto(LIBRARY_URL);
+    await cleanupOPFS(page);
+    const hhc = await seedOPFSPatch(page, { targetName: 'hhc-test' });
+    const hho = await seedOPFSPatch(page, { targetName: 'hho-test' });
+    const snare = await seedOPFSPatch(page, { targetName: 'snare-test' });
+    await seedSubfolder(page, 'patches', 'DRUMS');
+    await connectLibraryOPFS(page);
+
+    for (const dir of [hhc.patchDirName, hho.patchDirName, snare.patchDirName]) {
+      await expect(page.getByTestId(`library-patch-${dir}`)).toBeVisible({ timeout: 5_000 });
+    }
+
+    // Ctrl-click each row to build the multi-selection.
+    for (const dir of [hhc.patchDirName, hho.patchDirName, snare.patchDirName]) {
+      await page.getByTestId(`library-patch-${dir}`).click({ modifiers: ['ControlOrMeta'] });
+    }
+
+    const sourceRow = await treeRowFor(page, `library-patch-${hhc.patchDirName}`);
+    const drumsRow = await folderRowByText(page, 'DRUMS');
+    await simulateDragAndDrop(page, sourceRow as never, drumsRow as never);
+
+    for (const dir of [hhc.patchDirName, hho.patchDirName, snare.patchDirName]) {
+      await expect
+        .poll(
+          () => assertOpfsHasPatch(page, ['library', 's330', 'patches', 'DRUMS'], dir),
+          { timeout: 5_000 },
+        )
+        .toBe(true);
+      expect(await assertOpfsHasPatch(page, ['library', 's330', 'patches'], dir)).toBe(false);
+    }
   });
 });

--- a/tools/check-chevron-sizing.sh
+++ b/tools/check-chevron-sizing.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# check-chevron-sizing.sh
+#
+# Fails the build if any CSS file contains a class name with the
+# substring "chevron" outside the single canonical primitive file
+# (`modules/editor-core/src/design/chevron-primitives.css`).
+#
+# Background — why this gate is shaped this way:
+#
+# The project has a hard accessibility rule that every disclosure
+# chevron must be 1.1rem square in the accent color. The prior
+# architecture had four hand-coded chevron CSS classes
+# (`.ac-list-bank-chevron`, `.ac-tree-chevron`, `.ac-tree-chevron-btn`,
+# `.ac-device-memory-section-eyebrow-chevron`) that "agreed by
+# convention." One drifted to 1rem in May 2026 without anyone
+# noticing.
+#
+# A prior version of this gate allow-listed those four classes by
+# name and only failed when a NEW chevron class showed up. That was
+# the wrong shape: an allow-listed class can drift on a later edit
+# (e.g., `.ac-device-memory-section-eyebrow-chevron` going from
+# 1.1rem to 1rem) without tripping the gate, because the gate
+# never checked the values inside an allow-listed class.
+#
+# The corrected shape is: there is ONE chevron — the AcChevron
+# React component, backed by ONE CSS class (`.ac-chevron`) declared
+# in ONE file (chevron-primitives.css). Every disclosure surface
+# renders <AcChevron expanded={...} />. The gate enforces this
+# structurally by forbidding the substring "chevron" inside any CSS
+# class definition outside the canonical file — agents physically
+# cannot author a divergent chevron class without removing this gate
+# or editing the canonical file.
+#
+# What this gate does NOT check:
+# - Plain English comments mentioning "chevron" in any file are fine.
+# - JSX/TSX is unconstrained; chevron-related component code is
+#   expected to live in editor-core/src/components/AcChevron.tsx.
+# - Rust, Go, Python, Markdown, etc. are not scanned.
+
+set -uo pipefail
+
+# The single canonical chevron CSS file. Nothing else may declare a
+# chevron-named class. Treat any change to this list as a design-
+# system change that needs explicit operator approval.
+CANONICAL_CHEVRON_CSS="modules/editor-core/src/design/chevron-primitives.css"
+
+# Walk every CSS file under modules/. For each file other than the
+# canonical one, scan for selectors that contain a class name with
+# the substring "chevron". Selector recognition: a `.` followed by
+# class-name chars containing "chevron", followed eventually by `{`
+# or `,` (selector terminators). This catches both `.foo-chevron {`
+# and `.foo-chevron, .bar { ... }` shapes.
+violations=()
+
+while IFS= read -r file; do
+  # Skip the canonical file — it is the one and only place a chevron
+  # class declaration is allowed.
+  if [[ "$file" == "$CANONICAL_CHEVRON_CSS" ]]; then
+    continue
+  fi
+  # grep for selector-shaped chevron lines. The pattern matches a
+  # dot-prefixed identifier containing "chevron" followed by `{` or
+  # `,`, which covers both single-selector and grouped-selector
+  # declarations. Skip @-rule and comment lines.
+  while IFS= read -r line; do
+    line_no="${line%%:*}"
+    line_text="${line#*:}"
+    # Skip comment-only lines (start with `*` after indent, or `/*`,
+    # or `//`). The selector recognizer would otherwise misread
+    # `* .ac-foo-chevron is …` as a declaration.
+    case "${line_text##[[:space:]]}" in
+      \**|/\**|//*) continue ;;
+    esac
+    violations+=("$file:$line_no  $line_text")
+  done < <(grep -nE '\.[A-Za-z0-9_-]*chevron[A-Za-z0-9_-]*[[:space:]]*[,{]' "$file" 2>/dev/null || true)
+done < <(
+  find modules \
+    \( -path '*/dist/*' -o -path '*/node_modules/*' -o -path '*/.tmp/*' -o -path '*/test-results/*' \) -prune \
+    -o -name '*.css' -type f -print 2>/dev/null | sort
+)
+
+if [[ ${#violations[@]} -eq 0 ]]; then
+  echo "[chevron-check] OK — only the canonical chevron declaration exists"
+  exit 0
+fi
+
+cat <<EOF >&2
+
+[chevron-check] FAIL — chevron-named CSS class declared outside the
+canonical primitive file.
+
+There is exactly one chevron allowed in the design system:
+  CSS:       $CANONICAL_CHEVRON_CSS
+  Component: modules/editor-core/src/components/AcChevron.tsx
+  Render:    <AcChevron expanded={isExpanded} />
+
+Do NOT author a new chevron-named CSS class. Wrap your disclosure
+toggle around the AcChevron component instead. If the wrapping
+button needs a class (e.g., to add cursor / padding / hit-area
+chrome), name it after its role — disclosure-toggle, list-bank-
+toggle, section-eyebrow — never after its child glyph.
+
+See .claude/rules/chevron-sizing.md for the full rule + the incident
+that forced the rule into a structural gate.
+
+Offending declarations:
+
+EOF
+for v in "${violations[@]}"; do
+  echo "  $v" >&2
+done
+echo >&2
+exit 1


### PR DESCRIPTION
## Summary

Three intertwined bodies of work on the Roland S-330/S-550 editor library page.

- **Chevron architecture rewrite** — four hand-coded chevron CSS classes consolidated into one `AcChevron` React component backed by `.ac-chevron` in `chevron-primitives.css`. Pre-commit gate rewritten to forbid the substring "chevron" in any CSS class outside the canonical file (prior allow-list-by-name approach missed the silent value drift that drove the operator's fourth chevron-size escalation). Agents physically cannot author a divergent chevron without removing the gate or editing the canonical file.
- **Device-memory multi-select + batch export** — ctrl/cmd-click toggles non-contiguous selection, shift-click ranges from anchor. Drag of any member of a >1 set emits a batch payload that opens a new `BatchExportDrawer`. The batch loop runs items serially, **continues past per-item failures** (each failure surfaces as a ✗ row in the step log with the per-item error message), and refreshes the library once at the end. Replaces the prior behavior where one bad slot aborted the whole batch.
- **v3 UX work accumulated across the feature** — export dialogs migrated to `SlideDrawer` + `SteppedProgressDrawer`, BUG-001 silent-failure shape eliminated, auto-fetch missing tones on patch export, auto-refresh library after export, drop-on-folder honors target subfolder, MIME-gated dragover, scope-grouped library tree with collapsible sections + inset hierarchy bands, library move regressions fixed (move-to-folder, batch move, stale-selection clear, multi-select anchor highlight), s550 surface-token override.

## Test plan

- [ ] `make` — full monorepo build (green at HEAD)
- [ ] `make test-wiring-roland ARGS='library-flows-dnd.spec.ts'` — 14/14 pass at HEAD (D-LIB-06/07/08/09/14/21/24/25/26/27/28/29/30/31)
- [ ] `bash tools/check-chevron-sizing.sh` — must print "OK — only the canonical chevron declaration exists"
- [ ] Pre-commit hook fires both `check-css-duplication` and `check-chevron-sizing` on any CSS-touching commit
- [ ] **Browser smoke (S-330)**: load library, ctrl-click 3 tone slots, drag any one to the Tones section, see drawer titled "Export 3 tones to library" with 3 item rows; click Export, watch the step log advance with bytes/elapsed per item; verify all 3 tones land in the library tree.
- [ ] **Browser smoke (S-330, continue-on-error)**: select 3+ tone slots where one is known to fail on the device (e.g. a slot that returns no wave data); confirm the failed item shows ✗ with the error message, the surviving items show ✓, and the summary reads "X of N tones exported · Y failed".
- [ ] **Browser smoke (chevron)**: cycle through every disclosure surface (library sections, tree folders, device-memory section eyebrows, ToneList/PatchList bank headers) and confirm every chevron renders at the same 1.1rem accent size — visually identical to the pre-change behavior.

## Commits

- `51f3149b` — feat(library): chevron architecture rewrite + multi-select batch export + v3 UX work (54 files)
- `d83dc823` — docs: session-end 2026-05-21 journal entry
- `4c6a37de` — fix(library): batch export continues on per-item error + non-contiguous Cmd-click test
- `6cc38a69` — test(library): wire D-LIB-31 to cover continue-on-error contract via `__samplerClient` test seam

## Honest gaps

- **Hardware smoke against a real device** has not been run from this branch — wiring tests cover the JSX/state contract but stop short of pushing through `client.requestWaveData` to a physical S-330 or S-550. The single-item flows have hardware coverage today and the batch flow reuses the same library helpers, so the risk is low but non-zero.
- **Mid-batch cancellation** still unavailable — the SlideDrawer's Cancel button is disabled while operating, inherited from the single-item flow. Continue-on-error mitigates the worst case (one bad item no longer cascades) but doesn't address operator-initiated abort.
- **handleExportTone / handleExportPatch / handleBatchExport share wave-fetch + classify code with subtle progress-accounting differences.** Acknowledged DRY debt; deliberately not refactored in this PR because the extraction is non-trivial and the duplication is contained. Worth a dedicated dispatch.
